### PR TITLE
Properly save bookmark description

### DIFF
--- a/src/core/BookmarksManager.cpp
+++ b/src/core/BookmarksManager.cpp
@@ -110,7 +110,7 @@ void BookmarksManager::writeBookmark(QXmlStreamWriter *writer, BookmarkInformati
 
 			if (!bookmark->description.isEmpty())
 			{
-				writer->writeAttribute(QLatin1String("desc"), bookmark->description);
+				writer->writeTextElement(QLatin1String("desc"), bookmark->description);
 			}
 
 			writer->writeEndElement();


### PR DESCRIPTION
Bawiąc się przeglądarką, zauważyłem, że nie zapisuje poprawnie opisów zakładek. Przysyłam łatkę, licząc na owocną współpracę ;) .
