### PR TITLE
Fix tabbar popups on wrong monitor

### DIFF
--- a/src/ui/TabBarWidget.cpp
+++ b/src/ui/TabBarWidget.cpp
@@ -313,12 +313,12 @@ void TabBarWidget::showPreview(int index)
 
 		const QRect screen = QApplication::desktop()->screenGeometry(this);
 
-		if ((position.x() + m_previewWidget->width()) > screen.width())
+		if ((position.x() + m_previewWidget->width()) > screen.bottomRight().x())
 		{
 			position.setX(screen.width() - m_previewWidget->width());
 		}
 
-		if ((position.y() + m_previewWidget->height()) > screen.height())
+		if ((position.y() + m_previewWidget->height()) > screen.bottomRight().y())
 		{
 			position.setY(screen.height() - m_previewWidget->height());
 		}


### PR DESCRIPTION
- Fixes #45
- Widget position should be checked against screen.bottomRight,
  rather than screen.height and screen.width
