### PR TITLE
Add ctrl/shift key modifiers for link click

### DIFF
--- a/src/modules/backends/web/qtwebkit/QtWebKitWebWidget.cpp
+++ b/src/modules/backends/web/qtwebkit/QtWebKitWebWidget.cpp
@@ -1480,6 +1480,33 @@ bool QtWebKitWebWidget::eventFilter(QObject *object, QEvent *event)
 		else if (event->type() == QEvent::MouseButtonPress)
 		{
 			QMouseEvent *mouseEvent = static_cast<QMouseEvent*>(event);
+			Qt::KeyboardModifiers modifiers = mouseEvent->modifiers();
+
+			if (mouseEvent->button() == Qt::LeftButton)
+			{
+				m_hitResult = m_webView->page()->mainFrame()->hitTestContent(mouseEvent->pos());
+
+				if (m_hitResult.linkUrl().isValid())
+				{
+					if (modifiers.testFlag(Qt::ControlModifier))
+					{
+						triggerAction(OpenLinkInNewTabBackgroundAction);
+
+						event->accept();
+
+						return true;
+					}
+					else if (modifiers.testFlag(Qt::ShiftModifier))
+					{
+						triggerAction(OpenLinkInNewTabAction);
+
+						event->accept();
+
+						return true;
+					}
+				}
+
+			}
 
 			if (mouseEvent->button() == Qt::MiddleButton)
 			{


### PR DESCRIPTION
- ctrl+click = open in new background tab
- shift+click = open in new tab

I'm not sure if this is the best way to do this. I originally looked to use emit requestedOpenUrl, like the middle click option, but couldn't find a way to do open link in new (non-background) tab using that. I'm also not sure if it's safe to touch m_hitResult from here. Please verify that this should be okay before merging.
