### PR TITLE
Fix wrong signalt attached to the 'Do you want to resend data?' dialog

### DIFF
--- a/src/modules/backends/web/qtwebkit/QtWebKitWebPage.cpp
+++ b/src/modules/backends/web/qtwebkit/QtWebKitWebPage.cpp
@@ -194,18 +194,18 @@ bool QtWebKitWebPage::acceptNavigationRequest(QWebFrame *frame, const QNetworkRe
 	if (type == QWebPage::NavigationTypeFormResubmitted && SettingsManager::getValue(QLatin1String("Choices/WarnFormResend")).toBool())
 	{
 		bool cancel = false;
-		bool warn = true;
+		bool warn = SettingsManager::getValue(QLatin1String("Choices/WarnFormResend")).Bool;
 
 		if (m_webWidget)
 		{
 			ContentsDialog dialog(Utils::getIcon(QLatin1String("dialog-warning")), tr("Question"), tr("Are you sure that you want to send form data again?"), tr("Do you want to resend data?"), (QDialogButtonBox::Yes | QDialogButtonBox::Cancel), NULL, m_webWidget);
-			dialog.setCheckBox(tr("Do not show this message again"), true);
+			dialog.setCheckBox(tr("Do not show this message again"), !warn);
 
 			QEventLoop eventLoop;
 
 			m_webWidget->showDialog(&dialog);
 
-			connect(&dialog, SIGNAL(finished(int)), &eventLoop, SLOT(quit()));
+			connect(&dialog, SIGNAL(closed(bool,QDialogButtonBox::StandardButton)), &eventLoop, SLOT(quit()));
 			connect(this, SIGNAL(destroyed()), &eventLoop, SLOT(quit()));
 
 			eventLoop.exec();


### PR DESCRIPTION
Fix an issue with the "Are you sure that you want to send form data again?" dialog never going away from the screen. The issue is due to the wrong signal being attached to the dialog.
