### PR TITLE
Restart the transfer when content-lenght is 0, fixes #275

### DIFF
--- a/src/core/TransfersManager.cpp
+++ b/src/core/TransfersManager.cpp
@@ -301,6 +301,7 @@ TransferInformation* TransfersManager::startTransfer(QNetworkReply *reply, const
 	transfer->device = &temporaryFile;
 	transfer->started = QDateTime::currentDateTime();
 	transfer->isPrivate = privateTransfer;
+	transfer->bytesTotal = reply->header(QNetworkRequest::ContentLengthHeader);
 
 	if (!transfer->device->open(QIODevice::ReadWrite))
 	{
@@ -543,6 +544,11 @@ bool TransfersManager::resumeTransfer(TransferInformation *transfer)
 	if (!m_transfers.contains(transfer) || m_replies.key(transfer) || transfer->state != ErrorTransfer || !QFile::exists(transfer->target))
 	{
 		return false;
+	}
+	
+	if (transfer->bytesTotal == 0)
+	{
+		return restartTransfer(transfer);
 	}
 
 	QFile *file = new QFile(transfer->target);


### PR DESCRIPTION
Instead of adding to the same file between each stop/resume, the transfer is restarded when the server do not provide a content-length.

(please be careful when merging this fix, I'm really rusty at coding)
