### PR TITLE
Get the correct values of position from session

### DIFF
--- a/src/core/SessionsManager.cpp
+++ b/src/core/SessionsManager.cpp
@@ -235,7 +235,8 @@ SessionInformation SessionsManager::getSession(const QString &path)
 				WindowHistoryEntry historyEntry;
 				historyEntry.url = sessionData.value(QStringLiteral("%1/%2/History/%3/url").arg(i).arg(j).arg(k), 0).toString();
 				historyEntry.title = sessionData.value(QStringLiteral("%1/%2/History/%3/title").arg(i).arg(j).arg(k), 1).toString();
-				historyEntry.position = sessionData.value(QStringLiteral("%1/%2/History/%3/position").arg(i).arg(j).arg(k), 1).toPoint();
+				QStringList pos = sessionData.value(QStringLiteral("%1/%2/History/%3/position").arg(i).arg(j).arg(k), 1).toStringList();
+                		historyEntry.position = QPoint(pos.at(0).toInt(), pos.at(1).toInt());
 				historyEntry.zoom = sessionData.value(QStringLiteral("%1/%2/History/%3/zoom").arg(i).arg(j).arg(k), 100).toInt();
 
 				sessionWindow.history.append(historyEntry);


### PR DESCRIPTION
The session manager was always reading (0,0) has the position of the page.
Correct a part of #183

There may be a better way of doing that.
