### PR TITLE
Implement opening local files with relative paths, fixes Emdek/Otter#371

### DIFF
--- a/src/ui/AddressWidget.cpp
+++ b/src/ui/AddressWidget.cpp
@@ -29,6 +29,7 @@
 #include "../core/Utils.h"
 
 #include <QtCore/QDir>
+#include <QtCore/QFileInfo>
 #include <QtCore/QRegularExpression>
 #include <QtCore/QStandardPaths>
 #include <QtCore/QTimer>
@@ -238,6 +239,13 @@ void AddressWidget::handleUserInput(const QString &text)
 
 			return;
 		}
+	}
+
+	if (QFileInfo.exists(text))
+	{
+		emit requestedLoadUrl(QUrl::fromLocalFile(QFileInfo(text).canonicalFilePath()));
+
+		return;
 	}
 
 	const QUrl url = QUrl::fromUserInput(text);


### PR DESCRIPTION
This commit fixes opening files by relative paths (#371), checking if the path exists (using QFileInfo).
If it does, it will open generated file:// URL. else it will go on, generating http:// URL.
