### PR TITLE
Fix default search engine tickbox issue

### DIFF
--- a/src/ui/PreferencesDialog.cpp
+++ b/src/ui/PreferencesDialog.cpp
@@ -617,7 +617,7 @@ void PreferencesDialog::editSearch()
 	engineData[QLatin1String("title")] = index.data(Qt::DisplayRole).toString();
 	engineData[QLatin1String("description")] = index.data(Qt::ToolTipRole).toString();
 	engineData[QLatin1String("icon")] = index.data(Qt::DecorationRole).value<QIcon>();
-    engineData[QLatin1String("isDefault")] = m_defaultSearch;
+	engineData[QLatin1String("isDefault")] = m_defaultSearch;
 
 	QStringList keywords;
 

--- a/src/ui/SearchPropertiesDialog.cpp
+++ b/src/ui/SearchPropertiesDialog.cpp
@@ -40,10 +40,10 @@ SearchPropertiesDialog::SearchPropertiesDialog(const QVariantHash &engineData, c
 	m_ui->descriptionLineEdit->setText(engineData[QLatin1String("description")].toString());
 	m_ui->keywordLineEdit->setText(engineData[QLatin1String("keyword")].toString());
 	m_ui->keywordLineEdit->setValidator(new QRegularExpressionValidator(QRegularExpression((keywords.isEmpty() ? QString() : QStringLiteral("(?!\\b(%1)\\b)").arg(keywords.join('|'))) + "[a-z0-9]*"), m_ui->keywordLineEdit));
-    if (engineData[QLatin1String("isDefault")] == engineData[QLatin1String("title")].toString().toLower())
-    {
-        m_ui->defaultSearchCheckBox->setChecked(true);
-    }
+	if (engineData[QLatin1String("isDefault")] == engineData[QLatin1String("title")].toString().toLower())
+	{
+		m_ui->defaultSearchCheckBox->setChecked(true);
+	}
 
 
 	connect(m_ui->resultsPostMethodCheckBox, SIGNAL(toggled(bool)), m_ui->resultsPostWidget, SLOT(setEnabled(bool)));


### PR DESCRIPTION
Fixes issure where default tickbox for search engines remains ticked on old search engine even when a new one is chosen.
