### PR TITLE
Reduce image file name in context menu

### DIFF
--- a/src/modules/backends/web/qtwebkit/QtWebKitWebWidget.cpp
+++ b/src/modules/backends/web/qtwebkit/QtWebKitWebWidget.cpp
@@ -1044,7 +1044,7 @@ void QtWebKitWebWidget::showContextMenu(const QPoint &position)
 		flags |= ImageMenu;
 
 		const bool isImageOpened = getUrl().matches(m_hitResult.imageUrl(), (QUrl::NormalizePathSegments | QUrl::RemoveFragment | QUrl::StripTrailingSlash));
-		const QString fileName = m_hitResult.imageUrl().fileName();
+		const QString fileName = fontMetrics().elidedText(m_hitResult.imageUrl().fileName(), Qt::ElideMiddle, 256);
 		QAction *openImageAction = getAction(OpenImageInNewTabAction);
 		openImageAction->setText((fileName.isEmpty() || m_hitResult.imageUrl().scheme() == QLatin1String("data")) ? tr("Open Image (Untitled)") : tr("Open Image (%1)").arg(fileName));
 		openImageAction->setEnabled(!isImageOpened);


### PR DESCRIPTION
When the name of the image file is too large, the context menu is shown ugly and glitches. The long name of image file can be generated in contextual advertising banners services (Yandex.Direct, Google AdSense etc.).

I created a [test HTML-page](http://exl.wen.ru/otter_test1.html), where you can see even a full-screen context menu.

Screen №1: [ugly context menu](http://i.imgur.com/nTlBTfh.png)
Screen №2: [full-screen context menu](http://i.imgur.com/16Q9sZS.png)

I propose to reduce the image name.
