### PR TITLE
Prevent new tab button from being above tabs when dragged

### DIFF
--- a/src/ui/TabBarDockWidget.cpp
+++ b/src/ui/TabBarDockWidget.cpp
@@ -65,7 +65,6 @@ void TabBarDockWidget::setup(QMenu *closedWindowsMenu)
 	m_newTabButton->setDefaultAction(ActionsManager::getAction(QLatin1String("NewTab"), this));
 	m_newTabButton->setFixedSize(32, 32);
 	m_newTabButton->show();
-	m_newTabButton->raise();
 	m_newTabButton->move(m_tabBar->geometry().topRight());
 
 	connect(this, SIGNAL(dockLocationChanged(Qt::DockWidgetArea)), m_tabBar, SLOT(setOrientation(Qt::DockWidgetArea)));


### PR DESCRIPTION
I don't know why raise() was added. It means that a tab is underneath when dragged which look silly.
![screenshot from 2014-07-22 21 45 35](https://cloud.githubusercontent.com/assets/3157750/3657499/d47ca824-1195-11e4-905a-723205313c7c.png)
