### PR TITLE
Store temporary download files in a temporary location, fixes #500

### DIFF
--- a/src/core/TransfersManager.cpp
+++ b/src/core/TransfersManager.cpp
@@ -304,7 +304,7 @@ TransferInformation* TransfersManager::startTransfer(QNetworkReply *reply, const
 	}
 
 	QPointer<QNetworkReply> replyPointer = reply;
-	QTemporaryFile temporaryFile(QLatin1String("otter-download-XXXXXX.dat"), m_instance);
+	QTemporaryFile temporaryFile(QStandardPaths::writableLocation(QStandardPaths::TempLocation) + QLatin1String("/otter-download-XXXXXX.dat"), m_instance);
 	TransferInformation *transfer = new TransferInformation();
 	transfer->source = reply->url().toString(QUrl::RemovePassword | QUrl::PreferLocalFile);
 	transfer->device = &temporaryFile;


### PR DESCRIPTION
Use the system's **TempLocation** (/tmp in *nix, %TEMP% in Windows) to store the temporary files used when saving files.
