### PR TITLE
Updated design of PreviewWidget simmilar to Opera 12

### DIFF
--- a/src/ui/PreviewWidget.cpp
+++ b/src/ui/PreviewWidget.cpp
@@ -25,7 +25,7 @@
 namespace Otter
 {
 
-PreviewWidget::PreviewWidget(QWidget *parent) : QWidget(parent),
+PreviewWidget::PreviewWidget(QWidget *parent) : QFrame(parent),
 	m_textLabel(new QLabel(this)),
 	m_pixmapLabel(new QLabel(this)),
 	m_moveAnimation(NULL)
@@ -52,6 +52,10 @@ PreviewWidget::PreviewWidget(QWidget *parent) : QWidget(parent),
 	m_pixmapLabel->setFixedWidth(260);
 	m_pixmapLabel->setAlignment(Qt::AlignCenter);
 	m_pixmapLabel->setPalette(palette);
+	m_pixmapLabel->setStyleSheet("border-width: 1px; border-style: solid; border-color: gray; border-radius: 0px");
+
+	this->setObjectName("previewWidget");
+	this->setStyleSheet("#previewWidget {border-width: 1px; border-style: solid; border-color: #B3B3B3; border-radius: 4px}");
 }
 
 void PreviewWidget::setPosition(const QPoint &position)

--- a/src/ui/PreviewWidget.h
+++ b/src/ui/PreviewWidget.h
@@ -22,11 +22,12 @@
 
 #include <QtCore/QPropertyAnimation>
 #include <QtWidgets/QLabel>
+#include <QtWidgets/QFrame>
 
 namespace Otter
 {
 
-class PreviewWidget : public QWidget
+class PreviewWidget : public QFrame
 {
 	Q_OBJECT
 


### PR DESCRIPTION
Preview Before:
![previewwidget_before](https://cloud.githubusercontent.com/assets/720808/4916588/bcf3a494-64da-11e4-89f4-afa0b32e3bf4.png)
Preview After:
![previewwidget_after](https://cloud.githubusercontent.com/assets/720808/4916589/bebd570c-64da-11e4-8686-0c65a0f9dbbd.png)

It was annoying for me to see that yellow preview. I've added some CSS styles.
If you are planing to have Skins in Otter than these styles should be moved to a skin.
