### PR TITLE
Fixed case sensitive HTTP header lookup in TransferManager. 

### DIFF
--- a/src/core/TransfersManager.cpp
+++ b/src/core/TransfersManager.cpp
@@ -305,7 +305,7 @@ TransferInformation* TransfersManager::startTransfer(QNetworkReply *reply, const
 	}
 
 	QPointer<QNetworkReply> replyPointer = reply;
-	QTemporaryFile temporaryFile(QStandardPaths::writableLocation(QStandardPaths::TempLocation) + QLatin1String("/otter-download-XXXXXX.dat"), m_instance);
+	QTemporaryFile temporaryFile(QStandardPaths::writableLocation(QStandardPaths::TempLocation) + QDir::separator() + QLatin1String("otter-download-XXXXXX.dat"), m_instance);
 	TransferInformation *transfer = new TransferInformation();
 	transfer->source = reply->url().toString(QUrl::RemovePassword | QUrl::PreferLocalFile);
 	transfer->device = &temporaryFile;
@@ -346,7 +346,7 @@ TransferInformation* TransfersManager::startTransfer(QNetworkReply *reply, const
 		QUrl url;
 		QString fileName;
 
-		if (reply->rawHeaderList().contains(QStringLiteral("Content-Disposition").toLatin1()))
+		if (reply->hasRawHeader(QStringLiteral("Content-Disposition").toLatin1()))
 		{
 			url = QUrl(QRegularExpression(QLatin1String(" filename=\"?([^\"]+)\"?")).match(QString(reply->rawHeader(QStringLiteral("Content-Disposition").toLatin1()))).captured(1));
 
@@ -403,7 +403,7 @@ TransferInformation* TransfersManager::startTransfer(QNetworkReply *reply, const
 
 		if (quickTransfer)
 		{
-			path = SettingsManager::getValue(QLatin1String("Paths/Downloads")).toString() + QLatin1Char('/') + fileName;
+			path = SettingsManager::getValue(QLatin1String("Paths/Downloads")).toString() + QDir::separator() + fileName;
 
 			if (QFile::exists(path) && QMessageBox::question(SessionsManager::getActiveWindow(), tr("Question"), tr("File with that name already exists.\nDo you want to overwite it?"), (QMessageBox::Yes | QMessageBox::No)) == QMessageBox::No)
 			{
@@ -534,7 +534,7 @@ QString TransfersManager::getSavePath(const QString &fileName, QString path)
 	{
 		if (path.isEmpty())
 		{
-			QFileDialog dialog(SessionsManager::getActiveWindow(), tr("Save File"), SettingsManager::getValue(QLatin1String("Paths/SaveFile")).toString() + '/' + fileName);
+			QFileDialog dialog(SessionsManager::getActiveWindow(), tr("Save File"), SettingsManager::getValue(QLatin1String("Paths/SaveFile")).toString() + QDir::separator() + fileName, tr("All files (*)"));
 			dialog.setFileMode(QFileDialog::AnyFile);
 			dialog.setAcceptMode(QFileDialog::AcceptSave);
 


### PR DESCRIPTION
Fixed bug with case insensetive "Content-Disposition" HTTP header processing.
Steps to reproduce:
1. Open URL http://www.opera.com/ru/computer/thanks?ni=stable&os=windows
2. Wait till download starts.
Actual result: Downloading of a file named "windows" starts
Expected result: Downloading of "Opera_NI_stable.exe" starts

The problem is, that `reply->rawHeaderList().contains(...)` makes search case sensitive. Replaced with `reply->hasRawHeader(...)`

P.S. Added default "All files (*)" filter for file save dialog.
