### PR TITLE
Status tip event is sent to MainWindow, fixes #610

### DIFF
--- a/src/core/WindowsManager.cpp
+++ b/src/core/WindowsManager.cpp
@@ -682,7 +682,7 @@ void WindowsManager::setStatusMessage(const QString &message)
 {
 	QStatusTipEvent event(message);
 
-	QApplication::sendEvent(this, &event);
+	QApplication::sendEvent(MainWindow::findMainWindow(parent()), &event);
 }
 
 void WindowsManager::setTabBar(TabBarWidget *tabBar)


### PR DESCRIPTION
This commit changes `WindowsManager::setStatusMessage()` method. It sent event to wrong object. Now it sends it to the main window.
