### PR TITLE
Add action `OpenImageInNewBackgroundTab`

### DIFF
--- a/src/core/ActionsManager.cpp
+++ b/src/core/ActionsManager.cpp
@@ -148,6 +148,7 @@ bool Action::isLocal(int identifier)
 		case ActionsManager::ReloadFrameAction:
 		case ActionsManager::ViewFrameSourceAction:
 		case ActionsManager::OpenImageInNewTabAction:
+		case ActionsManager::OpenImageInNewTabBackgroundAction:
 		case ActionsManager::SaveImageToDiskAction:
 		case ActionsManager::CopyImageToClipboardAction:
 		case ActionsManager::CopyImageUrlToClipboardAction:
@@ -301,7 +302,8 @@ ActionsManager::ActionsManager(QObject *parent) : QObject(parent),
 	registerAction(CopyFrameLinkToClipboardAction, QT_TRANSLATE_NOOP("actions", "Copy Frame Link to Clipboard"));
 	registerAction(ReloadFrameAction, QT_TRANSLATE_NOOP("actions", "Reload"), QT_TRANSLATE_NOOP("actions", "Reload Frame"));
 	registerAction(ViewFrameSourceAction, QT_TRANSLATE_NOOP("actions", "View Frame Source"));
-	registerAction(OpenImageInNewTabAction, QT_TRANSLATE_NOOP("actions", "Open Image"));
+	registerAction(OpenImageInNewTabAction, QT_TRANSLATE_NOOP("actions", "Open Image In New Tab"));
+	registerAction(OpenImageInNewTabBackgroundAction, QT_TRANSLATE_NOOP("actions", "Open Image in New Background Tab"));
 	registerAction(SaveImageToDiskAction, QT_TRANSLATE_NOOP("actions", "Save Image…"));
 	registerAction(CopyImageToClipboardAction, QT_TRANSLATE_NOOP("actions", "Copy Image to Clipboard"));
 	registerAction(CopyImageUrlToClipboardAction, QT_TRANSLATE_NOOP("actions", "Copy Image Link to Clipboard"));

--- a/src/core/ActionsManager.h
+++ b/src/core/ActionsManager.h
@@ -122,6 +122,7 @@ public:
 		ReloadFrameAction,
 		ViewFrameSourceAction,
 		OpenImageInNewTabAction,
+		OpenImageInNewTabBackgroundAction,
 		SaveImageToDiskAction,
 		CopyImageToClipboardAction,
 		CopyImageUrlToClipboardAction,

--- a/src/modules/backends/web/qtwebengine/QtWebEngineWebWidget.cpp
+++ b/src/modules/backends/web/qtwebengine/QtWebEngineWebWidget.cpp
@@ -393,6 +393,13 @@ void QtWebEngineWebWidget::triggerAction(int identifier, bool checked)
 			}
 
 			break;
+		case ActionsManager::OpenImageInNewTabBackgroundAction:
+			if (!m_hitResult.imageUrl.isEmpty())
+			{
+				openUrl(m_hitResult.imageUrl, NewBackgroundTabOpen);
+			}
+
+			break;
 		case ActionsManager::SaveImageToDiskAction:
 			if (m_hitResult.imageUrl.isValid())
 			{
@@ -1366,8 +1373,14 @@ void QtWebEngineWebWidget::updateImageActions()
 
 	if (m_actions.contains(ActionsManager::OpenImageInNewTabAction))
 	{
-		m_actions[ActionsManager::OpenImageInNewTabAction]->setOverrideText(isImage ? (fileName.isEmpty() || m_hitResult.imageUrl.scheme() == QLatin1String("data")) ? tr("Open Image (Untitled)") : tr("Open Image (%1)").arg(fileName) : QT_TRANSLATE_NOOP("actions", "Open Image"));
+		m_actions[ActionsManager::OpenImageInNewTabAction]->setOverrideText(isImage ? (fileName.isEmpty() || m_hitResult.imageUrl.scheme() == QLatin1String("data")) ? tr("Open Image in New Tab (Untitled)") : tr("Open Image in New Tab (%1)").arg(fileName) : QT_TRANSLATE_NOOP("actions", "Open Image in New Tab"));
 		m_actions[ActionsManager::OpenImageInNewTabAction]->setEnabled(isImage && !isOpened);
+	}
+
+	if (m_actions.contains(ActionsManager::OpenImageInNewTabBackgroundAction))
+	{
+		m_actions[ActionsManager::OpenImageInNewTabBackgroundAction]->setOverrideText(isImage ? (fileName.isEmpty() || m_hitResult.imageUrl.scheme() == QLatin1String("data")) ? tr("Open Image in New Background Tab (Untitled)") : tr("Open Image in New Background Tab (%1)").arg(fileName) : QT_TRANSLATE_NOOP("actions", "Open Image in New Background Tab"));
+		m_actions[ActionsManager::OpenImageInNewTabBackgroundAction]->setEnabled(isImage && !isOpened);
 	}
 
 	if (m_actions.contains(ActionsManager::SaveImageToDiskAction))
@@ -1780,6 +1793,7 @@ Action* QtWebEngineWebWidget::getAction(int identifier)
 
 			break;
 		case ActionsManager::OpenImageInNewTabAction:
+		case ActionsManager::OpenImageInNewTabBackgroundAction:
 		case ActionsManager::SaveImageToDiskAction:
 		case ActionsManager::CopyImageUrlToClipboardAction:
 		case ActionsManager::ReloadImageAction:

--- a/src/modules/backends/web/qtwebkit/QtWebKitWebWidget.cpp
+++ b/src/modules/backends/web/qtwebkit/QtWebKitWebWidget.cpp
@@ -870,8 +870,14 @@ void QtWebKitWebWidget::updateImageActions()
 
 	if (m_actions.contains(ActionsManager::OpenImageInNewTabAction))
 	{
-		m_actions[ActionsManager::OpenImageInNewTabAction]->setOverrideText(isImage ? (fileName.isEmpty() || getCurrentHitTestResult().imageUrl.scheme() == QLatin1String("data")) ? tr("Open Image (Untitled)") : tr("Open Image (%1)").arg(fileName) : QT_TRANSLATE_NOOP("actions", "Open Image"));
+		m_actions[ActionsManager::OpenImageInNewTabAction]->setOverrideText(isImage ? (fileName.isEmpty() || getCurrentHitTestResult().imageUrl.scheme() == QLatin1String("data")) ? tr("Open Image in New Tab (Untitled)") : tr("Open Image in New Tab (%1)").arg(fileName) : QT_TRANSLATE_NOOP("actions", "Open Image in New Tab"));
 		m_actions[ActionsManager::OpenImageInNewTabAction]->setEnabled(isImage && !isOpened);
+	}
+
+	if (m_actions.contains(ActionsManager::OpenImageInNewTabBackgroundAction))
+	{
+		m_actions[ActionsManager::OpenImageInNewTabBackgroundAction]->setOverrideText(isImage ? (fileName.isEmpty() || getCurrentHitTestResult().imageUrl.scheme() == QLatin1String("data")) ? tr("Open Image in New Background Tab (Untitled)") : tr("Open Image in New Background Tab (%1)").arg(fileName) : QT_TRANSLATE_NOOP("actions", "Open Image in New Background Tab"));
+		m_actions[ActionsManager::OpenImageInNewTabBackgroundAction]->setEnabled(isImage && !isOpened);
 	}
 
 	if (m_actions.contains(ActionsManager::SaveImageToDiskAction))
@@ -1211,6 +1217,13 @@ void QtWebKitWebWidget::triggerAction(int identifier, bool checked)
 			if (!getCurrentHitTestResult().imageUrl.isEmpty())
 			{
 				openUrl(getCurrentHitTestResult().imageUrl, NewTabOpen);
+			}
+
+			break;
+		case ActionsManager::OpenImageInNewTabBackgroundAction:
+			if (!getCurrentHitTestResult().imageUrl.isEmpty())
+			{
+				openUrl(getCurrentHitTestResult().imageUrl, NewBackgroundTabOpen);
 			}
 
 			break;
@@ -2039,6 +2052,7 @@ Action* QtWebKitWebWidget::getAction(int identifier)
 
 			break;
 		case ActionsManager::OpenImageInNewTabAction:
+		case ActionsManager::OpenImageInNewTabBackgroundAction:
 		case ActionsManager::SaveImageToDiskAction:
 		case ActionsManager::CopyImageToClipboardAction:
 		case ActionsManager::CopyImageUrlToClipboardAction:

--- a/src/ui/WebWidget.cpp
+++ b/src/ui/WebWidget.cpp
@@ -576,6 +576,7 @@ void WebWidget::showContextMenu(const QPoint &position, MenuFlags flags)
 		if (flags & ImageMenu)
 		{
 			menu.addAction(getAction(ActionsManager::OpenImageInNewTabAction));
+			menu.addAction(getAction(ActionsManager::OpenImageInNewTabBackgroundAction));
 			menu.addAction(getAction(ActionsManager::ReloadImageAction));
 			menu.addAction(getAction(ActionsManager::CopyImageUrlToClipboardAction));
 			menu.addSeparator();


### PR DESCRIPTION
Adds a new action to open an image in a background tab. Later, this can be used with the configurable context menus according to user preference.

Also adjusts default text of OpenImageInNewTab to indicate that it opens the image in a new tab.