### PR TITLE
Set the default backend to qtwebengine when it is avilable

### DIFF
--- a/otter.pro
+++ b/otter.pro
@@ -434,3 +434,18 @@ TRANSLATIONS += resources/translations/otter-browser_cs_CZ.ts \
     resources/translations/otter-browser_zh_TW.ts
 
 RC_FILE = otter-browser.rc
+
+greaterThan(QT_MAJOR_VERSION, 4) : greaterThan(QT_MINOR_VERSION, 3) {
+DEFINES += OTTER_ENABLE_QTWEBENGINE
+QT += webengine webenginewidgets
+
+SOURCES +=      src/modules/backends/web/qtwebengine/QtWebEnginePage.cpp \
+                src/modules/backends/web/qtwebengine/QtWebEngineWebBackend.cpp \
+                src/modules/backends/web/qtwebengine/QtWebEngineWebWidget.cpp
+
+HEADERS +=      src/modules/backends/web/qtwebengine/QtWebEnginePage.h \
+                src/modules/backends/web/qtwebengine/QtWebEngineWebBackend.h \
+                src/modules/backends/web/qtwebengine/QtWebEngineWebWidget.h
+
+RESOURCES += src/modules/backends/web/qtwebengine/QtWebEngineResources.qrc
+}

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -227,7 +227,14 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv),
 
 		for (int j = 0; j < keys.count(); ++j)
 		{
-			SettingsManager::setDefaultValue(QStringLiteral("%1/%2").arg(groups.at(i)).arg(keys.at(j)), defaults.value(QStringLiteral("%1/value").arg(keys.at(j))));
+#ifdef OTTER_ENABLE_QTWEBENGINE
+            // Set the default backend to qtwebengine when it is avilable
+            if(QStringLiteral("%1/%2").arg(groups.at(i)).arg(keys.at(j)) == "Backends/Web")
+            {
+                defaults.setValue(QStringLiteral("%1/value").arg(keys.at(j)), "qtwebengine");
+            }
+#endif
+            SettingsManager::setDefaultValue(QStringLiteral("%1/%2").arg(groups.at(i)).arg(keys.at(j)), defaults.value(QStringLiteral("%1/value").arg(keys.at(j))));
 		}
 
 		defaults.endGroup();

--- a/src/modules/backends/web/qtwebkit/QtWebKitNetworkManager.cpp
+++ b/src/modules/backends/web/qtwebkit/QtWebKitNetworkManager.cpp
@@ -314,8 +314,12 @@ void QtWebKitNetworkManager::updateOptions(const QUrl &url)
 {
 	if (!m_backend)
 	{
-		m_backend = AddonsManager::getWebBackend(QLatin1String("qtwebkit"));
-	}
+#ifdef OTTER_ENABLE_QTWEBENGINE
+        m_backend = AddonsManager::getWebBackend(QLatin1String("qtwebengine"));
+#else
+        m_backend = AddonsManager::getWebBackend(QLatin1String("qtwebkit"));
+#endif
+    }
 
 	QString acceptLanguage = SettingsManager::getValue(QLatin1String("Network/AcceptLanguage"), url).toString();
 	acceptLanguage = ((acceptLanguage.isEmpty()) ? QLatin1String(" ") : acceptLanguage.replace(QLatin1String("system"), QLocale::system().bcp47Name()));

--- a/src/modules/windows/configuration/ConfigurationContentsWidget.cpp
+++ b/src/modules/windows/configuration/ConfigurationContentsWidget.cpp
@@ -50,11 +50,11 @@ ConfigurationContentsWidget::ConfigurationContentsWidget(Window *window) : Conte
 		const QStringList keys = defaults.childGroups();
 
 		for (int j = 0; j < keys.count(); ++j)
-		{
-			const QString key = QStringLiteral("%1/%2").arg(groups.at(i)).arg(keys.at(j));
+        {
+            const QString key = QStringLiteral("%1/%2").arg(groups.at(i)).arg(keys.at(j));
 			const QString type = defaults.value(QStringLiteral("%1/type").arg(keys.at(j))).toString();
 			const QVariant value = SettingsManager::getValue(key);
-			QList<QStandardItem*> optionItems;
+            QList<QStandardItem*> optionItems;
 			optionItems.append(new QStandardItem(keys.at(j)));
 			optionItems.append(new QStandardItem(type));
 			optionItems.append(new QStandardItem(value.toString()));


### PR DESCRIPTION
I have made small changes to the otter source code to make the default backend to qtwebengine when it is avilable since qtwebkit has been set to deprecated on Qt 5.5.