### PR TITLE
Initial hidpi support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,6 +66,7 @@ int main(int argc, char *argv[])
 	qInstallMessageHandler(otterMessageHander);
 
 	Application application(argc, argv);
+	application.setAttribute(Qt::AA_UseHighDpiPixmaps, true);
 
 	if (application.isRunning() || application.isUpdating())
 	{

--- a/src/modules/backends/web/qtwebkit/QtWebKitWebWidget.cpp
+++ b/src/modules/backends/web/qtwebkit/QtWebKitWebWidget.cpp
@@ -1714,7 +1714,9 @@ QIcon QtWebKitWebWidget::getIcon() const
 
 QPixmap QtWebKitWebWidget::getThumbnail()
 {
-	if (!m_thumbnail.isNull() || isLoading())
+	const qreal dpiRatio = this->devicePixelRatio();
+
+	if (!m_thumbnail.isNull() && m_thumbnail.devicePixelRatio() == dpiRatio || isLoading())
 	{
 		return m_thumbnail;
 	}
@@ -1751,7 +1753,8 @@ QPixmap QtWebKitWebWidget::getThumbnail()
 
 	painter.end();
 
-	pixmap = pixmap.scaled(thumbnailSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+	pixmap = pixmap.scaled(thumbnailSize * dpiRatio, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+	pixmap.setDevicePixelRatio(dpiRatio);
 
 	newView->deleteLater();
 

--- a/src/modules/backends/web/qtwebkit/QtWebKitWebWidget.cpp
+++ b/src/modules/backends/web/qtwebkit/QtWebKitWebWidget.cpp
@@ -1714,9 +1714,7 @@ QIcon QtWebKitWebWidget::getIcon() const
 
 QPixmap QtWebKitWebWidget::getThumbnail()
 {
-	const qreal dpiRatio = this->devicePixelRatio();
-
-	if (!m_thumbnail.isNull() && m_thumbnail.devicePixelRatio() == dpiRatio || isLoading())
+	if ((!m_thumbnail.isNull() && m_thumbnail.devicePixelRatio() == devicePixelRatio()) || isLoading())
 	{
 		return m_thumbnail;
 	}
@@ -1753,8 +1751,8 @@ QPixmap QtWebKitWebWidget::getThumbnail()
 
 	painter.end();
 
-	pixmap = pixmap.scaled(thumbnailSize * dpiRatio, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-	pixmap.setDevicePixelRatio(dpiRatio);
+	pixmap = pixmap.scaled((thumbnailSize * devicePixelRatio()), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+	pixmap.setDevicePixelRatio(devicePixelRatio());
 
 	newView->deleteLater();
 

--- a/src/ui/TabBarWidget.cpp
+++ b/src/ui/TabBarWidget.cpp
@@ -733,7 +733,10 @@ void TabBarWidget::updateButtons()
 					QStyleOption option;
 					option.rect = QRect(0, 0, 16, 16);
 
-					QPixmap pixmap(16, 16);
+					const qreal dpiRatio = this->devicePixelRatio();
+
+					QPixmap pixmap(QSize(16, 16) * dpiRatio);
+					pixmap.setDevicePixelRatio(dpiRatio);
 					pixmap.fill(Qt::transparent);
 
 					QPainter painter(&pixmap);

--- a/src/ui/TabBarWidget.cpp
+++ b/src/ui/TabBarWidget.cpp
@@ -733,10 +733,8 @@ void TabBarWidget::updateButtons()
 					QStyleOption option;
 					option.rect = QRect(0, 0, 16, 16);
 
-					const qreal dpiRatio = this->devicePixelRatio();
-
-					QPixmap pixmap(QSize(16, 16) * dpiRatio);
-					pixmap.setDevicePixelRatio(dpiRatio);
+					QPixmap pixmap(QSize(16, 16) * devicePixelRatio());
+					pixmap.setDevicePixelRatio(devicePixelRatio());
 					pixmap.fill(Qt::transparent);
 
 					QPainter painter(&pixmap);

--- a/src/ui/toolbars/SearchWidget.cpp
+++ b/src/ui/toolbars/SearchWidget.cpp
@@ -110,7 +110,7 @@ void SearchWidget::paintEvent(QPaintEvent *event)
 
 	if (isEnabled())
 	{
-		currentData(Qt::DecorationRole).value<QIcon>().paint(&painter, m_selectButtonIconRectangle);
+		painter.drawPixmap(m_selectButtonIconRectangle, currentData(Qt::DecorationRole).value<QIcon>().pixmap(m_selectButtonIconRectangle.size()));
 
 		QStyleOption arrow;
 		arrow.initFrom(this);
@@ -119,7 +119,7 @@ void SearchWidget::paintEvent(QPaintEvent *event)
 		style()->drawPrimitive(QStyle::PE_IndicatorArrowDown, &arrow, &painter, this);
 	}
 
-	Utils::getIcon(QLatin1String("edit-find")).paint(&painter, m_searchButtonRectangle, Qt::AlignCenter, (isEnabled() ? QIcon::Active : QIcon::Disabled));
+	painter.drawPixmap(m_searchButtonRectangle, Utils::getIcon(QLatin1String("edit-find")).pixmap(m_searchButtonRectangle.size(), (isEnabled() ? QIcon::Active : QIcon::Disabled)));
 }
 
 void SearchWidget::resizeEvent(QResizeEvent *event)
@@ -134,15 +134,15 @@ void SearchWidget::resizeEvent(QResizeEvent *event)
 	const QRect rectangle = style()->subElementRect(QStyle::SE_LineEditContents, &panel, this);
 
 	m_selectButtonIconRectangle = rectangle;
-	m_selectButtonIconRectangle.setWidth(20);
+	m_selectButtonIconRectangle.setWidth(rectangle.height());
 	m_selectButtonIconRectangle = m_selectButtonIconRectangle.marginsRemoved(QMargins(2, 2, 2, 2));
 
 	m_selectButtonArrowRectangle = rectangle;
-	m_selectButtonArrowRectangle.setLeft(rectangle.left() + 20);
+	m_selectButtonArrowRectangle.setLeft(rectangle.left() + rectangle.height());
 	m_selectButtonArrowRectangle.setWidth(12);
 
 	m_searchButtonRectangle = rectangle;
-	m_searchButtonRectangle.setLeft(rectangle.right() - 20);
+	m_searchButtonRectangle.setLeft(rectangle.right() - rectangle.height());
 	m_searchButtonRectangle = m_searchButtonRectangle.marginsRemoved(QMargins(2, 2, 2, 2));
 
 	lineEdit()->resize((rectangle.width() - m_selectButtonIconRectangle.width() - m_selectButtonArrowRectangle.width() - m_searchButtonRectangle.width()), rectangle.height());


### PR DESCRIPTION
This allows icons and tab thumbnails to be more crisp with QT_DEVICE_PIXEL_RATIO=2 (or more). 

Not a silver bullet, though. Speed dial thumbnails are still blurry, but this can be easily workarounded with higher TileHeight & TileWidth and decreased ZoomLevel, and probably should be properly fixed by saving bigger or full-sized screenshots, which would be handy for playing with zoom. There are also several issues which seem to originate in Qt itself.