### PR TITLE
add /usr/share/myspell/{,dicts/} to search path for hunspell dictionaries

### DIFF
--- a/3rdparty/sonnet/src/plugins/hunspell/hunspellclient.cpp
+++ b/3rdparty/sonnet/src/plugins/hunspell/hunspellclient.cpp
@@ -57,7 +57,7 @@ HunspellClient::HunspellClient(QObject *parent)
 #ifdef Q_OS_MAC
     directories << QLatin1String("/System/Library/Spelling/");
 #else
-    directories << QLatin1String("/usr/share/hunspell/") << QLatin1String("/usr/local/share/hunspell/") << QLatin1String("/usr/local/share/mozilla-dicts/");
+    directories << QLatin1String("/usr/share/hunspell/") << QLatin1String("/usr/local/share/hunspell/") << QLatin1String("/usr/share/myspell/") << QLatin1String("/usr/share/myspell/dicts/") << QLatin1String("/usr/local/share/mozilla-dicts/");
 #endif
 
     const QString otterDirectory(qgetenv("OTTER_DICTIONARIES"));


### PR DESCRIPTION
 on Fedora Linux dictionary packages put files into /usr/share/myspell/ (so this is needed for to allow any dictionaries to be found)
 
the hunspell binary on Fedora also searches for dictionaries in /usr/share/myspell/dicts/ (so I also added this)