### PR TITLE
Addons whose name contained a dot were not loaded

### DIFF
--- a/src/core/AddonsManager.cpp
+++ b/src/core/AddonsManager.cpp
@@ -18,6 +18,7 @@
 **************************************************************************/
 
 #include "AddonsManager.h"
+#include "Console.h"
 #include "SessionsManager.h"
 #include "SettingsManager.h"
 #include "ThemesManager.h"
@@ -141,6 +142,10 @@ void AddonsManager::loadUserScripts()
 			script->setEnabled(enabledScripts.value(scripts.at(i).fileName(), false));
 
 			m_userScripts[scripts.at(i).fileName()] = script;
+		}
+		else
+		{
+			Console::addMessage(QCoreApplication::translate("main", "Failed to find User Script file: %1").arg(path), Console::OtherCategory, Console::WarningLevel);
 		}
 	}
 

--- a/src/modules/windows/addons/AddonsContentsWidget.cpp
+++ b/src/modules/windows/addons/AddonsContentsWidget.cpp
@@ -106,7 +106,7 @@ void AddonsContentsWidget::addAddon()
 		return;
 	}
 
-	const QString targetPath(QDir(SessionsManager::getWritableDataPath(QLatin1String("scripts"))).filePath(QFileInfo(sourcePath).baseName()));
+	const QString targetPath(QDir(SessionsManager::getWritableDataPath(QLatin1String("scripts"))).filePath(QFileInfo(sourcePath).completeBaseName()));
 
 	if (QFile::exists(targetPath))
 	{


### PR DESCRIPTION
For a UserJS addon, the expected script name will be the same as the
directory with a suffix ".js". So `AddonsContentsWidget::addAddon()`
must only remove the suffix of the selected addon file, using Qt's
`completeBaseName()` instead of truncating at the *first dot* with
`baseName()`.
    
The previous behavior made addons like `x.user.js` saved under
`x/x.user.js`, and then not loaded because `x/x.js` was expected.
Solves #1210

A second commit adds a warning log if a userscript is declared in the
config, but cannot be found on the filesystem.