### PR TITLE
added cmake configuration option to disable linking with Qt5Multimedia lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,16 @@ endif (COMPILER_SUPPORTS_CXX11)
 option(ENABLE_QTWEBENGINE "Enable QtWebEngine backend (requires Qt 5.6)" ON)
 option(ENABLE_QTWEBKIT "Enable QtWebKit backend (requires Qt 5.4)" ON)
 option(ENABLE_CRASHREPORTS "Enable built-in crash reporting (only for official builds)" OFF)
+option(ENABLE_MULTIMEDIA "Link with Qt5Multimedia package" ON)
 
-find_package(Qt5 5.4.0 REQUIRED COMPONENTS Core DBus Gui Multimedia Network PrintSupport Qml Widgets XmlPatterns)
+# apparently the OPTIONAL_COMPONENTS part of find_package doesn't work with Qt, so this is more awkward than it should be
+# see http://cmake.3232098.n2.nabble.com/find-package-REQUIRED-ignores-OPTIONAL-COMPONENTS-td7592903.html
+if (ENABLE_MULTIMEDIA)
+        find_package(Qt5 5.4.0 REQUIRED COMPONENTS Core DBus Gui Multimedia Network PrintSupport Qml Widgets XmlPatterns)
+else (ENABLE_MULTIMEDIA)
+        find_package(Qt5 5.4.0 REQUIRED COMPONENTS Core DBus Gui Network PrintSupport Qml Widgets XmlPatterns)
+endif (ENABLE_MULTIMEDIA)
+
 find_package(Qt5WebEngineWidgets 5.6.0 QUIET)
 find_package(Qt5WebKitWidgets 5.4.0 QUIET)
 find_package(Hunspell 1.3.0 QUIET)
@@ -377,6 +385,10 @@ if (Qt5WebKitWidgets_FOUND AND ENABLE_QTWEBKIT)
 	)
 endif (Qt5WebKitWidgets_FOUND AND ENABLE_QTWEBKIT)
 
+if (ENABLE_MULTIMEDIA)
+        add_definitions(-DOTTER_ENABLE_MULTIMEDIA)
+endif (ENABLE_MULTIMEDIA)
+
 if (ENABLE_CRASHREPORTS)
 	add_definitions(-DOTTER_ENABLE_CRASHREPORTS)
 	include_directories(${CMAKE_SOURCE_DIR}/3rdparty/breakpad/src/)
@@ -533,7 +545,10 @@ elseif (UNIX)
 	endif (ENABLE_CRASHREPORTS)
 endif (WIN32)
 
-target_link_libraries(otter-browser Qt5::Core Qt5::Gui Qt5::Multimedia Qt5::Network Qt5::PrintSupport Qt5::Qml Qt5::Widgets Qt5::XmlPatterns)
+target_link_libraries(otter-browser Qt5::Core Qt5::Gui Qt5::Network Qt5::PrintSupport Qt5::Qml Qt5::Widgets Qt5::XmlPatterns)
+if (ENABLE_MULTIMEDIA)
+        target_link_libraries(otter-browser Qt5::Multimedia)
+endif (ENABLE_MULTIMEDIA)
 
 set(XDG_APPS_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/share/applications CACHE FILEPATH "Install path for .desktop files")
 

--- a/src/core/NotificationsManager.cpp
+++ b/src/core/NotificationsManager.cpp
@@ -27,7 +27,9 @@
 #include <QtCore/QMetaEnum>
 #include <QtCore/QSettings>
 #include <QtCore/QTimer>
+#ifdef OTTER_ENABLE_MULTIMEDIA
 #include <QtMultimedia/QSoundEffect>
+#endif
 
 namespace Otter
 {
@@ -106,6 +108,7 @@ Notification* NotificationsManager::createNotification(int event, const QString 
 
 	if (!definition.playSound.isEmpty())
 	{
+#ifdef OTTER_ENABLE_MULTIMEDIA
 		QSoundEffect *effect(new QSoundEffect(m_instance));
 		effect->setSource(QUrl::fromLocalFile(definition.playSound));
 		effect->setLoopCount(1);
@@ -121,6 +124,7 @@ Notification* NotificationsManager::createNotification(int event, const QString 
 
 			effect->play();
 		}
+#endif
 	}
 
 	if (definition.showAlert)

--- a/src/ui/preferences/PreferencesAdvancedPageWidget.cpp
+++ b/src/ui/preferences/PreferencesAdvancedPageWidget.cpp
@@ -44,7 +44,9 @@
 #include <QtCore/QMimeDatabase>
 #include <QtCore/QSettings>
 #include <QtCore/QTimer>
+#ifdef OTTER_ENABLE_MULTIMEDIA
 #include <QtMultimedia/QSoundEffect>
+#endif
 #include <QtNetwork/QSslSocket>
 #include <QtNetwork/QSslCipher>
 #include <QtWidgets/QInputDialog>
@@ -461,6 +463,7 @@ void PreferencesAdvancedPageWidget::resizeEvent(QResizeEvent *event)
 
 void PreferencesAdvancedPageWidget::playNotificationSound()
 {
+#ifdef OTTER_ENABLE_MULTIMEDIA
 	QSoundEffect *effect(new QSoundEffect(this));
 	effect->setSource(QUrl::fromLocalFile(m_ui->notificationsPlaySoundFilePathWidget->getPath()));
 	effect->setLoopCount(1);
@@ -476,6 +479,7 @@ void PreferencesAdvancedPageWidget::playNotificationSound()
 
 		effect->play();
 	}
+#endif
 }
 
 void PreferencesAdvancedPageWidget::updateNotificationsActions()


### PR DESCRIPTION
This is kind of bizarre so feel free to take it or leave it. First, some background: I'm interested in programming audio applications so I have neither ALSA nor PulseAudio installed on my desktop; I use Jack. The problem is that all the browser packages on Ubuntu ultimately depend on ALSA/PulseAudio. Since I don't care about my browser having audio/video capabilities but I do need to check email and other javascript-heavy stuff (so lynx isn't an option), I decided to get the source code for Otter and remove the dependency on the audio system (in this case, QtMultimedia).

So, here are the changes I made to compile Otter without QtMultimedia. I wrote it so that a default build will still include the Multimedia component, you have to explicitly set the option to off to build without it. I figured I'd offer the code in case it was something you were interested in merging, but if you don't want to bother with it then just ignore it. :)

In any case, thanks for making an awesome browser!