### PR TITLE
Close tab to the left or right

### DIFF
--- a/src/core/ActionsManager.cpp
+++ b/src/core/ActionsManager.cpp
@@ -305,6 +305,8 @@ ActionsManager::ActionsManager(QObject *parent) : QObject(parent),
 	registerAction(SuspendTabAction, QT_TRANSLATE_NOOP("actions", "Suspend Tab"), QString(), QIcon(), ActionDefinition::WindowScope, ActionDefinition::NoFlags);
 	registerAction(CloseTabAction, QT_TRANSLATE_NOOP("actions", "Close Tab"), QString(), ThemesManager::createIcon(QLatin1String("tab-close")), ActionDefinition::WindowScope);
 	registerAction(CloseOtherTabsAction, QT_TRANSLATE_NOOP("actions", "Close Other Tabs"), QString(), ThemesManager::createIcon(QLatin1String("tab-close-other")), ActionDefinition::MainWindowScope);
+	registerAction(CloseTabsToTheLeftAction, QT_TRANSLATE_NOOP("actions", "Close Tabs to the Left"), QString(), QIcon(), ActionDefinition::MainWindowScope);
+	registerAction(CloseTabsToTheRightAction, QT_TRANSLATE_NOOP("actions", "Close Tabs to the Right"), QString(), QIcon(), ActionDefinition::MainWindowScope);
 	registerAction(ClosePrivateTabsAction, QT_TRANSLATE_NOOP("actions", "Close All Private Tabs"), QT_TRANSLATE_NOOP("actions", "Close All Private Tabs in Current Window"), QIcon(), ActionDefinition::MainWindowScope, ActionDefinition::NoFlags);
 	registerAction(ClosePrivateTabsPanicAction, QT_TRANSLATE_NOOP("actions", "Close Private Tabs and Windows"), QString(), QIcon(), ActionDefinition::ApplicationScope);
 	registerAction(ReopenTabAction, QT_TRANSLATE_NOOP("actions", "Reopen Previously Closed Tab"), QString(), QIcon(), ActionDefinition::MainWindowScope);

--- a/src/core/ActionsManager.h
+++ b/src/core/ActionsManager.h
@@ -104,6 +104,8 @@ public:
 		SuspendTabAction,
 		CloseTabAction,
 		CloseOtherTabsAction,
+		CloseTabsToTheLeftAction,
+		CloseTabsToTheRightAction,
 		ClosePrivateTabsAction,
 		ClosePrivateTabsPanicAction,
 		ReopenTabAction,

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -961,6 +961,28 @@ void MainWindow::triggerAction(int identifier, const QVariantMap &parameters)
 			}
 
 			break;
+		case ActionsManager::CloseTabsToTheLeftAction:
+			if (window)
+			{
+				for (int index=0; index < getWindowIndex(window->getIdentifier()); index++)
+				{
+					Window *leftWindow=getWindowByIndex(index);
+					if (!leftWindow->isPinned()) leftWindow->requestClose();
+				}
+			}
+
+			break;
+		case ActionsManager::CloseTabsToTheRightAction:
+			if (window)
+			{
+				for (int index=getWindowIndex(window->getIdentifier()) + 1; index < getWindowCount(); index++)
+				{
+					Window *rightWindow=getWindowByIndex(index);
+					if (!rightWindow->isPinned()) rightWindow->requestClose();
+				}
+			}
+
+			break;
 		case ActionsManager::ActivateTabAction:
 			if (window)
 			{

--- a/src/ui/TabBarWidget.cpp
+++ b/src/ui/TabBarWidget.cpp
@@ -721,6 +721,8 @@ void TabBarWidget::contextMenuEvent(QContextMenuEvent *event)
 			menu.addSeparator();
 			menu.addAction(new Action(ActionsManager::CloseTabAction, {}, windowExecutor, &menu));
 			menu.addAction(new Action(ActionsManager::CloseOtherTabsAction, {{QLatin1String("tab"), window->getIdentifier()}}, windowExecutor, &menu));
+			menu.addAction(new Action(ActionsManager::CloseTabsToTheLeftAction, {{QLatin1String("tab"), window->getIdentifier()}}, windowExecutor, &menu));
+			menu.addAction(new Action(ActionsManager::CloseTabsToTheRightAction, {{QLatin1String("tab"), window->getIdentifier()}}, windowExecutor, &menu));
 			menu.addAction(new Action(ActionsManager::ClosePrivateTabsAction, {}, mainWindowExecutor, &menu));
 		}
 	}


### PR DESCRIPTION
Vivaldi has a nice feature where you can close tabs to the left or right of the current tab. I wanted it in Otter so I added it, then figured might as well open a pull request for it.

I'd like to not show it on the left-most or right-most tabs, but I'm not sure how to get the tab count from within TabBarWidget.cpp.