### PR TITLE
Enable HiDPI scaling

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,8 +113,20 @@ int main(int argc, char *argv[])
 #endif
 #endif
 
+#if QT_VERSION >= 0x050900
+	// Enable automatic High-DPI scaling support. This could be done with earlier Qt
+	// versions as well (down to 5.6), but it was rather buggy before 5.9, so we
+	// restrict to 5.9 and higher.
+	// Users can force-enable this on olde Qt versions by setting the environment
+	// variable `QT_AUTO_SCREEN_SCALE_FACTOR=1`.
+	// Note that this attribute must be enabled before the QApplication is
+	// constructed, hence the use of the static version of setAttribute().
+	Application::setAttribute(Qt::AA_EnableHighDpiScaling, true);
+#endif
+	// Use static version for this attribute too, for consistency with the above.
+	Application::setAttribute(Qt::AA_UseHighDpiPixmaps, true);
+
 	Application application(argc, argv);
-	application.setAttribute(Qt::AA_UseHighDpiPixmaps, true);
 
 	if (Application::isAboutToQuit() || Application::isRunning() || Application::isUpdating() || Application::getCommandLineParser()->isSet(QLatin1String("report")))
 	{


### PR DESCRIPTION
Since Qt 5.6, DPI-aware applications can enable HiDPI scaling by
setting the appropriate Application attribute. This allows the windows
to adapt their rendering to the DPI of the screen holding the window,
thus automatically up/downscaling when moving between high and standard
DPI monitors.

The attribute must be set before the application is actually set up, so
use the static setAttribute() before creation. For consistency, use the
same static method for the pixmap attribute.