### PR TITLE
Save page screenshot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ set(otter_src
 	src/ui/OpenAddressDialog.cpp
 	src/ui/OpenBookmarkDialog.cpp
 	src/ui/OptionWidget.cpp
+	src/ui/PageScreenDialog.cpp
 	src/ui/PreferencesDialog.cpp
 	src/ui/PreviewWidget.cpp
 	src/ui/ProxyModel.cpp
@@ -285,6 +286,7 @@ qt5_wrap_ui(otter_ui
 	src/ui/MasterPasswordDialog.ui
 	src/ui/OpenAddressDialog.ui
 	src/ui/OpenBookmarkDialog.ui
+	src/ui/PageScreenDialog.ui
 	src/ui/PreferencesDialog.ui
 	src/ui/ReloadTimeDialog.ui
 	src/ui/ReportDialog.ui

--- a/resources/keyboard/default.json
+++ b/resources/keyboard/default.json
@@ -45,6 +45,12 @@
 				]
 			},
 			{
+				"action": "SavePageScreen",
+				"shortcuts": [
+					"Ctrl+Shift+S"
+				]
+			},
+			{
 				"action": "CloseTab",
 				"shortcuts": [
 					"Ctrl+W",

--- a/resources/menu/menuBar.json
+++ b/resources/menu/menuBar.json
@@ -12,6 +12,7 @@
 			"separator",
 			"Open",
 			"Save",
+			"SavePageScreen",
 			"CloseTab",
 			"separator",
 			{

--- a/src/core/ActionsManager.cpp
+++ b/src/core/ActionsManager.cpp
@@ -291,6 +291,9 @@ ActionsManager::ActionsManager(QObject *parent) : QObject(parent),
 	registerAction(NewWindowPrivateAction, QT_TRANSLATE_NOOP("actions", "New Private Window"), {}, ThemesManager::createIcon(QLatin1String("window-new-private")), ActionDefinition::ApplicationScope);
 	registerAction(OpenAction, QT_TRANSLATE_NOOP("actions", "Open…"), {}, ThemesManager::createIcon(QLatin1String("document-open")), ActionDefinition::MainWindowScope);
 	registerAction(SaveAction, QT_TRANSLATE_NOOP("actions", "Save…"), {}, ThemesManager::createIcon(QLatin1String("document-save")), ActionDefinition::WindowScope);
+	#ifdef OTTER_ENABLE_QTWEBKIT
+	registerAction(SavePageScreenAction, QT_TRANSLATE_NOOP("actions", "Save Page Screen"), {}, ThemesManager::createIcon(QLatin1String("image-loading")), ActionDefinition::WindowScope);
+	#endif
 	registerAction(CloneTabAction, QT_TRANSLATE_NOOP("actions", "Clone Tab"), {}, {}, ActionDefinition::WindowScope);
 	registerAction(PeekTabAction, QT_TRANSLATE_NOOP("actions", "Peek Tab"), {}, {}, ActionDefinition::MainWindowScope);
 	registerAction(PinTabAction, QT_TRANSLATE_NOOP("actions", "Pin Tab"), {}, {}, ActionDefinition::WindowScope);

--- a/src/core/ActionsManager.h
+++ b/src/core/ActionsManager.h
@@ -105,6 +105,7 @@ public:
 		NewWindowPrivateAction,
 		OpenAction,
 		SaveAction,
+		SavePageScreenAction,
 		CloneTabAction,
 		PeekTabAction,
 		PinTabAction,

--- a/src/core/Utils.cpp
+++ b/src/core/Utils.cpp
@@ -530,6 +530,23 @@ QUrl normalizeUrl(QUrl url)
 	return url;
 }
 
+QString filterCharsFromFilename(const QString &name)
+{
+	QString value = name;
+
+	value.replace(QLatin1Char('/'), QLatin1Char('-'));
+	value.remove(QLatin1Char('\\'));
+	value.remove(QLatin1Char(':'));
+	value.remove(QLatin1Char('*'));
+	value.remove(QLatin1Char('?'));
+	value.remove(QLatin1Char('"'));
+	value.remove(QLatin1Char('<'));
+	value.remove(QLatin1Char('>'));
+	value.remove(QLatin1Char('|'));
+
+	return value;
+}
+
 QLocale createLocale(const QString &name)
 {
 	if (name == QLatin1String("pt"))

--- a/src/core/Utils.h
+++ b/src/core/Utils.h
@@ -105,6 +105,7 @@ QString formatFileTypes(const QStringList &filters = {});
 QString normalizePath(const QString &path);
 QUrl expandUrl(const QUrl &url);
 QUrl normalizeUrl(QUrl url);
+QString filterCharsFromFilename(const QString &name);
 QLocale createLocale(const QString &name);
 QPixmap loadPixmapFromDataUri(const QString &data);
 SaveInformation getSavePath(const QString &fileName, const QString &directory = {}, QStringList filters = {}, bool forceAsk = false);

--- a/src/modules/backends/web/qtwebkit/QtWebKitWebWidget.cpp
+++ b/src/modules/backends/web/qtwebkit/QtWebKitWebWidget.cpp
@@ -48,6 +48,7 @@
 #include "../../../../ui/SearchEnginePropertiesDialog.h"
 #include "../../../../ui/SourceViewerWebWidget.h"
 #include "../../../../ui/WebsitePreferencesDialog.h"
+#include "../../../../ui/PageScreenDialog.h"
 
 #include <QtCore/QDataStream>
 #include <QtCore/QFileInfo>
@@ -884,6 +885,13 @@ void QtWebKitWebWidget::triggerAction(int identifier, const QVariantMap &paramet
 
 					new Transfer(m_networkManager->get(request), path, (Transfer::CanAskForPathOption | Transfer::CanAutoDeleteOption | Transfer::CanOverwriteOption | Transfer::IsPrivateOption));
 				}
+			}
+
+			break;
+		case ActionsManager::SavePageScreenAction:
+			{
+				    PageScreenDialog* pageScreen = new PageScreenDialog(m_webView, this);
+				pageScreen->show();
 			}
 
 			break;

--- a/src/ui/PageScreenDialog.cpp
+++ b/src/ui/PageScreenDialog.cpp
@@ -1,0 +1,299 @@
+/**************************************************************************
+* Otter Browser: Web browser controlled by the user, not vice-versa.
+* Copyright (C) 2010-2014  David Rosca <nowrep@gmail.com>
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*
+**************************************************************************/
+#include "PageScreenDialog.h"
+#include "ui_PageScreenDialog.h"
+#include "../core/Application.h"
+#include "../core/SettingsManager.h"
+
+#ifdef OTTER_ENABLE_QTWEBKIT
+
+#include <QMessageBox>
+#include <QWebFrame>
+#include <QWebView>
+#include <QTimer>
+#include <QPushButton>
+#include <QCloseEvent>
+#include <QPrinter>
+
+#include <QtConcurrent/QtConcurrentRun>
+
+namespace Otter
+{
+
+PageScreenDialog::PageScreenDialog(QWebView* view, QWidget* parent)
+	: Dialog(parent)
+	, ui(new Ui::PageScreenDialog)
+	, m_spinnerAnimation(this)
+	, m_view(view)
+	, m_imageScaling(0)
+{
+	setAttribute(Qt::WA_DeleteOnClose);
+
+	ui->setupUi(this);
+
+	m_formats.append(QStringLiteral("PNG"));
+	m_formats.append(QStringLiteral("BMP"));
+	m_formats.append(QStringLiteral("JPG"));
+	m_formats.append(QStringLiteral("PPM"));
+	m_formats.append(QStringLiteral("TIFF"));
+	m_formats.append(QStringLiteral("PDF"));
+
+	foreach (const QString &format, m_formats)
+	{
+		ui->formats->addItem(tr("Save as %1").arg(format));
+	}
+
+	m_pageTitle = m_view->title();
+
+	const QString name = Utils::filterCharsFromFilename(m_pageTitle);
+	const QString path = SettingsManager::getOption(SettingsManager::Paths_SaveFileOption).toString();
+	ui->location->setText(QString("%1/%2.png").arg(path, name));
+
+	connect(&m_spinnerAnimation, &Animation::frameChanged, ui->label, [&]()
+	{
+		ui->label->setPixmap(m_spinnerAnimation.getCurrentPixmap());
+	});
+	m_spinnerAnimation.start();
+
+	connect(ui->changeLocation, SIGNAL(clicked()), this, SLOT(changeLocation()));
+	connect(ui->formats, SIGNAL(currentIndexChanged(int)), this, SLOT(formatChanged()));
+	connect(ui->buttonBox->button(QDialogButtonBox::Save), SIGNAL(clicked()), this, SLOT(dialogAccepted()));
+	connect(ui->buttonBox->button(QDialogButtonBox::Cancel), SIGNAL(clicked()), this, SLOT(close()));
+
+	QTimer::singleShot(200, this, SLOT(createThumbnail()));
+}
+
+void PageScreenDialog::formatChanged()
+{
+	QString text = ui->location->text();
+	int pos = text.lastIndexOf(QLatin1Char('.'));
+
+	if (pos > -1)
+	{
+		text = text.left(pos + 1) + m_formats.at(ui->formats->currentIndex()).toLower();
+	}
+	else
+	{
+		text.append(QLatin1Char('.') + m_formats.at(ui->formats->currentIndex()).toLower());
+	}
+
+	ui->location->setText(text);
+}
+
+void PageScreenDialog::changeLocation()
+{
+	const QString name = Utils::filterCharsFromFilename(m_pageTitle);
+	const QString path = Utils::getSavePath(name + "." + m_formats.at(ui->formats->currentIndex()).toLower(),
+	                                        SettingsManager::getOption(SettingsManager::Paths_SaveFileOption).toString(),
+	                                        {}, true).path;
+	if (!path.isEmpty())
+	{
+		ui->location->setText(path);
+	}
+}
+
+void PageScreenDialog::dialogAccepted()
+{
+	if (!ui->location->text().isEmpty())
+	{
+		if (QFile::exists(ui->location->text()))
+		{
+			const QString text = tr("File '%1' already exists. Do you want to overwrite it?").arg(ui->location->text());
+			QMessageBox::StandardButton button = QMessageBox::warning(this, tr("File already exists"), text,
+			                                     QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+
+			if (button != QMessageBox::Yes)
+			{
+				return;
+			}
+		}
+
+		QApplication::setOverrideCursor(Qt::WaitCursor);
+
+		const QString format = m_formats.at(ui->formats->currentIndex());
+		if (format == QLatin1String("PDF"))
+		{
+			saveAsDocument(format);
+		}
+		else
+		{
+			saveAsImage(format);
+		}
+
+		QApplication::restoreOverrideCursor();
+
+		close();
+	}
+}
+
+void PageScreenDialog::saveAsImage(const QString &format)
+{
+	const QString suffix = QLatin1Char('.') + format.toLower();
+
+	QString pathWithoutSuffix = ui->location->text();
+	if (pathWithoutSuffix.endsWith(suffix, Qt::CaseInsensitive))
+	{
+		pathWithoutSuffix = pathWithoutSuffix.mid(0, pathWithoutSuffix.length() - suffix.length());
+	}
+
+	if (m_pageImages.count() == 1)
+	{
+		m_pageImages.first().save(pathWithoutSuffix + suffix, format.toUtf8());
+	}
+	else
+	{
+		int part = 1;
+		foreach (const QImage &image, m_pageImages)
+		{
+			const QString fileName = pathWithoutSuffix + ".part" + QString::number(part);
+			image.save(fileName + suffix, format.toUtf8());
+			part++;
+		}
+	}
+}
+
+void PageScreenDialog::saveAsDocument(const QString &format)
+{
+	const QString suffix = QLatin1Char('.') + format.toLower();
+
+	QString pathWithoutSuffix = ui->location->text();
+	if (pathWithoutSuffix.endsWith(suffix, Qt::CaseInsensitive))
+	{
+		pathWithoutSuffix = pathWithoutSuffix.mid(0, pathWithoutSuffix.length() - suffix.length());
+	}
+
+	QPrinter printer;
+	printer.setCreator(QStringLiteral("%1 %2").arg(QGuiApplication::applicationDisplayName(), Application::getFullVersion()));
+	printer.setOutputFileName(pathWithoutSuffix + suffix);
+	printer.setOutputFormat(QPrinter::PdfFormat);
+	printer.setPaperSize(m_pageImages.first().size(), QPrinter::DevicePixel);
+	printer.setPageMargins(0, 0, 0, 0, QPrinter::DevicePixel);
+	printer.setFullPage(true);
+
+	QPainter painter;
+	painter.begin(&printer);
+
+	for (int i = 0; i < m_pageImages.size(); ++i)
+	{
+		const QImage image = m_pageImages.at(i);
+		painter.drawImage(0, 0, image);
+
+		if (i != m_pageImages.size() - 1)
+		{
+			printer.newPage();
+		}
+	}
+
+	painter.end();
+}
+
+void PageScreenDialog::createThumbnail()
+{
+	QWebPage* page = m_view->page();
+
+	const int heightLimit = 20000;
+	const QPoint originalScrollPosition = page->mainFrame()->scrollPosition();
+	const QSize originalSize = page->viewportSize();
+	const QSize frameSize = page->mainFrame()->contentsSize();
+	const int verticalScrollbarSize = page->mainFrame()->scrollBarGeometry(Qt::Vertical).width();
+	const int horizontalScrollbarSize = page->mainFrame()->scrollBarGeometry(Qt::Horizontal).height();
+
+	int yPosition = 0;
+	bool canScroll = frameSize.height() > heightLimit;
+
+	// We will split rendering page into smaller parts to avoid infinite loops
+	// or crashes.
+
+	do
+	{
+		int remainingHeight = frameSize.height() - yPosition;
+		if (remainingHeight <= 0)
+		{
+			break;
+		}
+
+		QSize size(frameSize.width(),
+		           remainingHeight > heightLimit ? heightLimit : remainingHeight);
+		page->setViewportSize(size);
+		page->mainFrame()->scroll(0, qMax(0, yPosition - horizontalScrollbarSize));
+
+		QImage image(page->viewportSize().width() - verticalScrollbarSize,
+		             page->viewportSize().height() - horizontalScrollbarSize,
+		             QImage::Format_ARGB32_Premultiplied);
+		QPainter painter(&image);
+		page->mainFrame()->render(&painter);
+		painter.end();
+
+		m_pageImages.append(image);
+
+		canScroll = remainingHeight > heightLimit;
+		yPosition += size.height();
+	}
+	while (canScroll);
+
+	page->setViewportSize(originalSize);
+	page->mainFrame()->setScrollBarValue(Qt::Vertical, originalScrollPosition.y());
+	page->mainFrame()->setScrollBarValue(Qt::Horizontal, originalScrollPosition.x());
+
+	m_imageScaling = new QFutureWatcher<QImage>(this);
+	m_imageScaling->setFuture(QtConcurrent::run(this, &PageScreenDialog::scaleImage));
+	connect(m_imageScaling, SIGNAL(finished()), SLOT(showImage()));
+}
+
+QImage PageScreenDialog::scaleImage()
+{
+	QVector<QImage> scaledImages;
+	int sumHeight = 0;
+
+	foreach (const QImage &image, m_pageImages)
+	{
+		QImage scaled = image.scaledToWidth(450, Qt::SmoothTransformation);
+
+		scaledImages.append(scaled);
+		sumHeight += scaled.height();
+	}
+
+	QImage finalImage(QSize(450, sumHeight), QImage::Format_ARGB32_Premultiplied);
+	QPainter painter(&finalImage);
+
+	int offset = 0;
+	foreach (const QImage &image, scaledImages)
+	{
+		painter.drawImage(0, offset, image);
+		offset += image.height();
+	}
+
+	return finalImage;
+}
+
+void PageScreenDialog::showImage()
+{
+	m_spinnerAnimation.stop();
+
+	ui->label->setPixmap(QPixmap::fromImage(m_imageScaling->result()));
+}
+
+PageScreenDialog::~PageScreenDialog()
+{
+	delete ui;
+}
+
+}
+
+#endif //OTTER_ENABLE_QTWEBKIT

--- a/src/ui/PageScreenDialog.h
+++ b/src/ui/PageScreenDialog.h
@@ -1,0 +1,76 @@
+/**************************************************************************
+* Otter Browser: Web browser controlled by the user, not vice-versa.
+* Copyright (C) 2010-2014  David Rosca <nowrep@gmail.com>
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*
+**************************************************************************/
+
+#ifndef PAGESCREEN_H
+#define PAGESCREEN_H
+
+#ifdef OTTER_ENABLE_QTWEBKIT
+
+#include <QFutureWatcher>
+#include "Dialog.h"
+#include "../ui/Animation.h"
+
+class QWebView;
+
+namespace Otter
+{
+
+namespace Ui
+{
+class PageScreenDialog;
+}
+
+class PageScreenDialog final : public Dialog
+{
+	Q_OBJECT
+
+public:
+	explicit PageScreenDialog(QWebView* view, QWidget* parent);
+	~PageScreenDialog();
+
+	QImage scaleImage();
+
+private slots:
+	void createThumbnail();
+	void showImage();
+
+	void formatChanged();
+	void changeLocation();
+	void dialogAccepted();
+
+private:
+	void saveAsImage(const QString &format);
+	void saveAsDocument(const QString &format);
+
+	void createPixmap();
+
+	Ui::PageScreenDialog* ui;
+	SpinnerAnimation m_spinnerAnimation;
+	QWebView* m_view;
+	QString m_pageTitle;
+
+	QFutureWatcher<QImage>* m_imageScaling;
+	QVector<QImage> m_pageImages;
+	QStringList m_formats;
+};
+
+}
+
+#endif //OTTER_ENABLE_QTWEBKIT
+#endif // PAGESCREEN_H

--- a/src/ui/PageScreenDialog.ui
+++ b/src/ui/PageScreenDialog.ui
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Otter::PageScreenDialog</class>
+ <widget class="QDialog" name="PageScreenDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>539</width>
+    <height>368</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Page Screen</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>531</width>
+        <height>264</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="1">
+      <layout class="QFormLayout" name="formLayout">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::ExpandingFieldsGrow</enum>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Format:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="formats"/>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Location:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLineEdit" name="location">
+           <property name="minimumSize">
+            <size>
+             <width>250</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="changeLocation">
+           <property name="text">
+            <string>Browse...</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="0">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Preferred</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="1" column="2">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Preferred</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="0" colspan="3">
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Sometimes dynamic pages cannot be saved as html or pdf with proper formatting. QupZilla had a function to save page as an image, I find it quite useful and have ported it to Otter.

There are also some translations (https://github.com/QupZilla/qupzilla/tree/v1.8.9/translations), but I was not able to cleanly update otter ts files.