### PR TITLE
Updated info and migrated to the latest AppStream specs

### DIFF
--- a/packaging/otter-browser.appdata.xml
+++ b/packaging/otter-browser.appdata.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Martin Gansser <martinkg@fedoraproject.org> -->
-<application>
-  <id type="desktop">otter-browser.desktop</id>
-  <metadata_license>CC0</metadata_license>
-  <project_license>GPLv3+</project_license>
+<component>
+  <id>org.otter_browser.Otter_Browser</id>
+  <launchable type="desktop-id">org.otter_browser.Otter_Browser.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
   <name>Otter Browser</name>
   <summary>Web browser controlled by the user, not vice-versa</summary>
   <description>
@@ -16,15 +17,38 @@
     <kudo>ModernToolkit</kudo>
   </kudos>
   <screenshots>
-    <screenshot type="default">http://p.im9.eu/1497.jpg</screenshot>
-    <screenshot>http://p.im9.eu/826.jpg</screenshot>
-    <screenshot>http://p.im9.eu/725.jpg</screenshot>
-    <screenshot>http://p.im9.eu/635.jpg</screenshot>
-    <screenshot>http://p.im9.eu/596.jpg</screenshot>
-    <screenshot>http://p.im9.eu/4121.jpg</screenshot>
-    <screenshot>http://p.im9.eu/3146.jpg</screenshot>
-    <screenshot>http://p.im9.eu/2176.jpg</screenshot>
+    <screenshot type="default">
+      <image>https://p.im9.eu/1497.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image>https://p.im9.eu/826.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image>https://p.im9.eu/725.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image>https://p.im9.eu/635.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image>https://p.im9.eu/596.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image>https://p.im9.eu/4121.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image>https://p.im9.eu/3146.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image>https://p.im9.eu/2176.jpg</image>
+    </screenshot>
   </screenshots>
-  <url type="homepage">http://otter-browser.org/</url>
-  <updatecontact>martinkg@fedoraproject.org</updatecontact>
-</application>
+  <url type="homepage">https://otter-browser.org/</url>
+  <url type="bugtracker">https://github.com/OtterBrowser/otter-browser/issues</url>
+  <url type="faq">https://otter-browser.org/#faq</url>
+  <url type="translate">https://www.transifex.com/otter-browser/otter-browser/</url>
+  <categories>
+    <category>Network</category>
+    <category>WebBrowser</category>
+  </categories>
+  <update_contact>martinkg@fedoraproject.org</update_contact>
+</component>


### PR DESCRIPTION
+ The ID is now following a reverse-DNS scheme as the AppStream specs require. Any hyphens has been replaced with underscores for compatibility as recommended.
+ Added a launchable tag for the desktop file
+ Specified metadata license
+ Replaced invalid/depricated SPDX License "GPLv3+" with "GPL-3.0-or-later"
+ Fixed the screenshots tags
+ Changed http to https for all supported urls
+ Added url tag for bugtracker, faq and translate
+ Added categories Network and WebBrowser