### PR TITLE
Hide Title Bar in the Otter Browser 1.0.xx

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+1.0.01 (2019-01-01):
+- some enhancements in experimental backend for QtWebEngine (Blink):
+-- download dialog is now shown for tab that initiated it;
+-- added support for handling requests to print page;
+- many other fixes.
+
 0.9.99 RC 12 (2018-09-01):
 - QtWebEngine backend no longer uses locks for fetching feeds, links or search engines;
 - some other fixes.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,14 +74,14 @@ set(CMAKE_CXX_STANDARD 11)
 include(FeatureSummary)
 include(GNUInstallDirs)
 
-option(ENABLE_QTWEBENGINE "Enable QtWebEngine backend (requires Qt 5.12)" ON)
+option(ENABLE_QTWEBENGINE "Enable QtWebEngine backend (requires Qt 5.9)" ON)
 option(ENABLE_QTWEBKIT "Enable QtWebKit backend (requires QtWebKit 5.212)" ON)
 option(ENABLE_CRASHREPORTS "Enable built-in crash reporting (only for official builds)" OFF)
 option(ENABLE_DBUS "Enable D-Bus based integration for notifications (only freedesktop.org compatible platforms)" ON)
 option(ENABLE_SPELLCHECK "Enable Hunspell based spell checking" ON)
 
 find_package(Qt5 5.6.0 REQUIRED COMPONENTS Core Gui Multimedia Network PrintSupport Qml Svg Widgets XmlPatterns)
-find_package(Qt5WebEngineWidgets 5.12.0 QUIET)
+find_package(Qt5WebEngineWidgets 5.9.0 QUIET)
 find_package(Qt5WebKitWidgets 5.212.0 QUIET)
 find_package(Hunspell 1.5.0 QUIET)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,16 +12,10 @@ project(otter-browser)
 
 set(MAJOR_VERSION "1")
 set(MINOR_VERSION "0")
-set(PATCH_VERSION "81")
+set(PATCH_VERSION "01")
 set(WEEKLY_VERSION "" CACHE STRING "")
 
-add_definitions(-DOTTER_VERSION_MAIN="${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}" -DOTTER_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}")
-
-if ("${WEEKLY_VERSION}" STREQUAL "")
-	add_definitions(-DOTTER_VERSION_CONTEXT="-dev" -DOTTER_VERSION_WEEKLY=" ")
-else ()
-	add_definitions(-DOTTER_VERSION_CONTEXT=" weekly ${WEEKLY_VERSION}" -DOTTER_VERSION_WEEKLY="${WEEKLY_VERSION}")
-endif ()
+add_definitions(-DOTTER_VERSION_MAIN="${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}" -DOTTER_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}" -DOTTER_VERSION_CONTEXT=" " -DOTTER_VERSION_WEEKLY=" ")
 
 if (EXISTS "${CMAKE_ROOT}/Modules/CPack.cmake")
 	include(InstallRequiredSystemLibraries)
@@ -501,7 +495,7 @@ elseif (APPLE)
 	set(MACOSX_BUNDLE_SHORT_VERSION_STRING ${MAJOR_VERSION}.${MINOR_VERSION})
 	set(MACOSX_BUNDLE_ICON_FILE otter-browser.icns)
 	set(MACOSX_BUNDLE_GUI_IDENTIFIER "org.otter-browser.otter-browser")
-	set(MACOSX_BUNDLE_COPYRIGHT "Copyright (C) 2013-2018 Otter Browser Team. All rights reserved.")
+	set(MACOSX_BUNDLE_COPYRIGHT "Copyright (C) 2013-2019 Otter Browser Team. All rights reserved.")
 	set(otter_src
 		${otter_src}
 		src/modules/platforms/mac/MacPlatformIntegration.mm

--- a/otter-browser.rc
+++ b/otter-browser.rc
@@ -4,8 +4,8 @@ IDI_ICON1 ICON DISCARDABLE "resources/icons/otter-browser.ico"
 IDI_ICON2 ICON DISCARDABLE "resources/icons/otter-browser-file-type.ico"
 
 VS_VERSION_INFO VERSIONINFO
-	FILEVERSION 1,0,8,1
-	PRODUCTVERSION 1,0,8,1
+	FILEVERSION 1,0,0,1
+	PRODUCTVERSION 1,0,0,1
 BEGIN
 	BLOCK "StringFileInfo"
 	BEGIN
@@ -13,12 +13,12 @@ BEGIN
 		BEGIN
 			VALUE "CompanyName", "Otter Browser Team"
 			VALUE "FileDescription", "Otter Browser"
-			VALUE "FileVersion", "1.0.81"
+			VALUE "FileVersion", "1.0.01"
 			VALUE "InternalName", "otter-browser"
-			VALUE "LegalCopyright", "Copyright (C) 2013-2018 Otter Browser Team"
+			VALUE "LegalCopyright", "Copyright (C) 2013-2019 Otter Browser Team"
 			VALUE "OriginalFilename", "otter-browser.exe"
 			VALUE "ProductName", "Otter Browser"
-			VALUE "ProductVersion", "1.0.81"
+			VALUE "ProductVersion", "1.0.01"
 		END
 	END
 	BLOCK "VarFileInfo"

--- a/src/modules/backends/web/qtwebengine/QtWebEngineWebBackend.cpp
+++ b/src/modules/backends/web/qtwebengine/QtWebEngineWebBackend.cpp
@@ -71,6 +71,7 @@ void QtWebEngineWebBackend::handleDownloadRequested(QWebEngineDownloadItem *item
 		return;
 	}
 
+#if QTWEBENGINECORE_VERSION >= 0x050C00
 	QtWebEnginePage *page(qobject_cast<QtWebEnginePage*>(item->page()));
 
 	if (page && page->getWebWidget())
@@ -79,6 +80,7 @@ void QtWebEngineWebBackend::handleDownloadRequested(QWebEngineDownloadItem *item
 
 		return;
 	}
+#endif
 
 	const HandlersManager::HandlerDefinition handler(HandlersManager::getHandler(transfer->getMimeType()));
 

--- a/src/modules/backends/web/qtwebengine/QtWebEngineWebWidget.cpp
+++ b/src/modules/backends/web/qtwebengine/QtWebEngineWebWidget.cpp
@@ -48,7 +48,9 @@
 #include <QtGui/QClipboard>
 #include <QtGui/QContextMenuEvent>
 #include <QtGui/QImageWriter>
+#if QTWEBENGINECORE_VERSION >= 0x050C00
 #include <QtPrintSupport/QPrintPreviewDialog>
+#endif
 #include <QtWebEngineCore/QWebEngineCookieStore>
 #include <QtWebEngineWidgets/QWebEngineHistory>
 #include <QtWebEngineWidgets/QWebEngineProfile>
@@ -62,7 +64,9 @@ namespace Otter
 
 QtWebEngineWebWidget::QtWebEngineWebWidget(const QVariantMap &parameters, WebBackend *backend, ContentsWidget *parent) : WebWidget(parameters, backend, parent),
 	m_webView(nullptr),
+#if QTWEBENGINECORE_VERSION >= 0x050B00
 	m_inspectorView(nullptr),
+#endif
 	m_page(new QtWebEnginePage(SessionsManager::calculateOpenHints(parameters).testFlag(SessionsManager::PrivateOpen), this)),
 	m_loadingState(FinishedLoadingState),
 	m_canGoForwardValue(UnknownValue),
@@ -90,7 +94,9 @@ QtWebEngineWebWidget::QtWebEngineWebWidget(const QVariantMap &parameters, WebBac
 	connect(m_page, &QtWebEnginePage::requestedNewWindow, this, &QtWebEngineWebWidget::requestedNewWindow);
 	connect(m_page, &QtWebEnginePage::authenticationRequired, this, &QtWebEngineWebWidget::handleAuthenticationRequired);
 	connect(m_page, &QtWebEnginePage::proxyAuthenticationRequired, this, &QtWebEngineWebWidget::handleProxyAuthenticationRequired);
+#if QTWEBENGINECORE_VERSION >= 0x050C00
 	connect(m_page, &QtWebEnginePage::printRequested, this, &QtWebEngineWebWidget::handlePrintRequest);
+#endif
 	connect(m_page, &QtWebEnginePage::windowCloseRequested, this, &QtWebEngineWebWidget::handleWindowCloseRequest);
 	connect(m_page, &QtWebEnginePage::fullScreenRequested, this, &QtWebEngineWebWidget::handleFullScreenRequest);
 	connect(m_page, &QtWebEnginePage::featurePermissionRequested, [&](const QUrl &url, QWebEnginePage::Feature feature)
@@ -885,6 +891,7 @@ void QtWebEngineWebWidget::triggerAction(int identifier, const QVariantMap &para
 			}
 
 			break;
+#if QTWEBENGINECORE_VERSION >= 0x050B00
 		case ActionsManager::InspectPageAction:
 			{
 				const bool showInspector(parameters.value(QLatin1String("isChecked"), !getActionState(identifier, parameters).isChecked).toBool());
@@ -905,6 +912,7 @@ void QtWebEngineWebWidget::triggerAction(int identifier, const QVariantMap &para
 			m_page->triggerAction(QWebEnginePage::InspectElement);
 
 			break;
+#endif
 		case ActionsManager::FullScreenAction:
 			{
 				const MainWindow *mainWindow(MainWindow::findMainWindow(this));
@@ -1013,6 +1021,7 @@ void QtWebEngineWebWidget::handleViewSourceReplyFinished()
 	}
 }
 
+#if QTWEBENGINECORE_VERSION >= 0x050C00
 void QtWebEngineWebWidget::handlePrintRequest()
 {
 	QPrintPreviewDialog printPreviewDialog(this);
@@ -1038,6 +1047,7 @@ void QtWebEngineWebWidget::handlePrintRequest()
 
 	printPreviewDialog.exec();
 }
+#endif
 
 void QtWebEngineWebWidget::handleAuthenticationRequired(const QUrl &url, QAuthenticator *authenticator)
 {
@@ -1226,7 +1236,9 @@ void QtWebEngineWebWidget::updateOptions(const QUrl &url)
 	settings->setAttribute(QWebEngineSettings::JavascriptCanAccessClipboard, getOption(SettingsManager::Permissions_ScriptsCanAccessClipboardOption, url).toBool());
 	settings->setAttribute(QWebEngineSettings::JavascriptCanOpenWindows, (getOption(SettingsManager::Permissions_ScriptsCanOpenWindowsOption, url).toString() != QLatin1String("blockAll")));
 	settings->setAttribute(QWebEngineSettings::LocalStorageEnabled, getOption(SettingsManager::Permissions_EnableLocalStorageOption, url).toBool());
+#if QTWEBENGINECORE_VERSION >= 0x050A00
 	settings->setAttribute(QWebEngineSettings::ShowScrollBars, getOption(SettingsManager::Interface_ShowScrollBarsOption, url).toBool());
+#endif
 	settings->setAttribute(QWebEngineSettings::WebGLEnabled, getOption(SettingsManager::Permissions_EnableWebglOption, url).toBool());
 	settings->setDefaultTextEncoding((encoding == QLatin1String("auto")) ? QString() : encoding);
 
@@ -1484,6 +1496,7 @@ WebWidget* QtWebEngineWebWidget::clone(bool cloneHistory, bool isPrivate, const 
 	return widget;
 }
 
+#if QTWEBENGINECORE_VERSION >= 0x050B00
 QWidget* QtWebEngineWebWidget::getInspector()
 {
 	if (!m_inspectorView)
@@ -1499,6 +1512,7 @@ QWidget* QtWebEngineWebWidget::getInspector()
 
 	return m_inspectorView;
 }
+#endif
 
 QWidget* QtWebEngineWebWidget::getViewport()
 {
@@ -1777,10 +1791,12 @@ bool QtWebEngineWebWidget::canFastForward() const
 	return (m_canGoForwardValue == TrueValue || canGoForward());
 }
 
+#if QTWEBENGINECORE_VERSION >= 0x050B00
 bool QtWebEngineWebWidget::canInspect() const
 {
 	return !Utils::isUrlEmpty(getUrl());
 }
+#endif
 
 bool QtWebEngineWebWidget::canRedo() const
 {
@@ -1829,10 +1845,12 @@ bool QtWebEngineWebWidget::isFullScreen() const
 	return m_isFullScreen;
 }
 
+#if QTWEBENGINECORE_VERSION >= 0x050B00
 bool QtWebEngineWebWidget::isInspecting() const
 {
 	return (m_inspectorView && m_inspectorView->isVisible());
 }
+#endif
 
 bool QtWebEngineWebWidget::isPopup() const
 {

--- a/src/modules/backends/web/qtwebengine/QtWebEngineWebWidget.h
+++ b/src/modules/backends/web/qtwebengine/QtWebEngineWebWidget.h
@@ -23,6 +23,7 @@
 #include "../../../../ui/WebWidget.h"
 
 #include <QtNetwork/QNetworkReply>
+#include <QtWebEngineCore/QtWebEngineCoreVersion>
 #include <QtWebEngineWidgets/QWebEngineFullScreenRequest>
 #include <QtWebEngineWidgets/QWebEngineView>
 
@@ -63,7 +64,9 @@ public:
 	void search(const QString &query, const QString &searchEngine) override;
 	void print(QPrinter *printer) override;
 	WebWidget* clone(bool cloneHistory = true, bool isPrivate = false, const QStringList &excludedOptions = {}) const override;
+#if QTWEBENGINECORE_VERSION >= 0x050B00
 	QWidget* getInspector();
+#endif
 	QWidget* getViewport() override;
 	QString getTitle() const override;
 	QString getDescription() const override;
@@ -126,12 +129,16 @@ protected:
 	bool canGoBack() const override;
 	bool canGoForward() const override;
 	bool canFastForward() const override;
+#if QTWEBENGINECORE_VERSION >= 0x050B00
 	bool canInspect() const;
+#endif
 	bool canRedo() const override;
 	bool canUndo() const override;
 	bool canShowContextMenu(const QPoint &position) const override;
 	bool canViewSource() const override;
+#if QTWEBENGINECORE_VERSION >= 0x050B00
 	bool isInspecting() const;
+#endif
 	bool isPopup() const override;
 	bool isScrollBar(const QPoint &position) const override;
 
@@ -139,7 +146,9 @@ protected slots:
 	void handleLoadStarted();
 	void handleLoadFinished();
 	void handleViewSourceReplyFinished();
+#if QTWEBENGINECORE_VERSION >= 0x050C00
 	void handlePrintRequest();
+#endif
 	void handleAuthenticationRequired(const QUrl &url, QAuthenticator *authenticator);
 	void handleProxyAuthenticationRequired(const QUrl &url, QAuthenticator *authenticator, const QString &proxy);
 	void handleFullScreenRequest(QWebEngineFullScreenRequest request);
@@ -152,7 +161,9 @@ protected slots:
 
 private:
 	QWebEngineView *m_webView;
+#if QTWEBENGINECORE_VERSION >= 0x050B00
 	QWebEngineView *m_inspectorView;
+#endif
 	QtWebEnginePage *m_page;
 	QDateTime m_lastUrlClickTime;
 	HitTestResult m_hitResult;

--- a/src/ui/Window.h
+++ b/src/ui/Window.h
@@ -97,8 +97,10 @@ protected:
 	void focusInEvent(QFocusEvent *event) override;
 	void updateFocus();
 	void setContentsWidget(ContentsWidget *widget);
+	bool event(QEvent *event) override;
 
 protected slots:
+	void handleIconChanged(const QIcon &icon);
 	void handleSearchRequest(const QString &query, const QString &searchEngine, SessionsManager::OpenHints hints = SessionsManager::DefaultOpen);
 	void handleGeometryChangeRequest(const QRect &geometry);
 	void handleToolBarStateChanged(int identifier, const ToolBarState &state);


### PR DESCRIPTION
One option I had in Opera Legacy 12 that I did not find in the Otter Browser is to hide the title bar, keeping the view only by the tabs (as most web browsers do, and almost always by default). The absence of this option is annoying, and I feel compelled to display the full-screen browser (F11) as an alternative, but it falls into issue #1571.