### PR TITLE
Do not display BookmarkPropertiesDialog when triggering BookmarkPageA…

### DIFF
--- a/src/ui/ContentsWidget.cpp
+++ b/src/ui/ContentsWidget.cpp
@@ -178,7 +178,7 @@ void ContentsWidget::triggerAction(int identifier, const QVariantMap &parameters
 			{
 				const QUrl url(parameters.value(QLatin1String("url"), getUrl()).toUrl().adjusted(QUrl::RemovePassword));
 
-				if (url.isEmpty())
+				if (Utils::isUrlEmpty(url))
 				{
 					break;
 				}


### PR DESCRIPTION
It doesn't make sense to be able to bookmark the about:start page.