### PR TITLE
Fix menuBar reappearing after switching from fullscreen to normal mode

### DIFF
--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -999,9 +999,12 @@ void MainWindow::triggerAction(int identifier, const QVariantMap &parameters, Ac
 
 							m_menuBar->show();
 						}
-						else if (!isChecked && (m_menuBar && m_menuBar->isVisible()))
+						else if (!isChecked && m_menuBar)
 						{
-							m_menuBar->hide();
+							m_menuBar->deleteLater();
+							m_menuBar = nullptr;
+
+							setMenuBar(nullptr);
 						}
 
 						break;


### PR DESCRIPTION
Fixes https://github.com/OtterBrowser/otter-browser/issues/1571.
When disabling menuBar, used same approach as when disabling statusBar.