### PR TITLE
Fix for segmentation fault error when entering string in address bar after clearing 'All' browsing history

### DIFF
--- a/src/core/HistoryModel.cpp
+++ b/src/core/HistoryModel.cpp
@@ -124,6 +124,9 @@ void HistoryModel::clearRecentEntries(uint period)
 	{
 		clear();
 
+		m_urls.clear();
+		m_identifiers.clear();
+
 		emit cleared();
 
 		return;


### PR DESCRIPTION
Fixes issue #1600 