### PR TITLE
Update downloadsItemView data before saving

### DIFF
--- a/src/ui/preferences/PreferencesAdvancedPageWidget.cpp
+++ b/src/ui/preferences/PreferencesAdvancedPageWidget.cpp
@@ -1672,6 +1672,8 @@ void PreferencesAdvancedPageWidget::save()
 
 	QFile::remove(SessionsManager::getReadableDataPath(QLatin1String("handlers.ini")));
 
+	updateDownloadsOptions();
+
 	for (int i = 0; i < m_ui->downloadsItemView->getRowCount(); ++i)
 	{
 		const QModelIndex index(m_ui->downloadsItemView->getIndex(i, 0));


### PR DESCRIPTION
Fixes #1624 

Video demo:
https://youtu.be/12UeUzMBaYs

A different approach (probably better) to fix this: #1626 