### PR TITLE
Add GitHub Action CI builds

### DIFF
--- a/.github/workflows/ci_build.yaml
+++ b/.github/workflows/ci_build.yaml
@@ -1,0 +1,110 @@
+name: CI Build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: "${{matrix.os}}, ${{matrix.qt_version}}, ${{matrix.build_type}}"
+    runs-on: ${{matrix.os}}
+    strategy:
+        fail-fast: false
+        matrix:
+          include:
+            # Windows fails because libhunspell-dev is missing. See https://github.com/OtterBrowser/otter-browser/issues/1684
+            #- os: windows-latest
+            #  build_type: qtwebengine
+            #  qt_version: 5.15.2
+            # TODO: Install QtWebKit on Windows
+            #- os: windows-latest
+            #  build_type: qtwebkit
+            #  qt_version: 5.15.2
+            - os: ubuntu-18.04
+              build_type: qtwebkit
+              qt_version: repository
+              apt-dependencies: git build-essential cmake qtbase5-dev libqt5core5a libqt5gui5 libqt5multimedia5 qtmultimedia5-dev libqt5network5 libqt5printsupport5 libqt5qml5 qtdeclarative5-dev libqt5svg5 libqt5svg5-dev libqt5widgets5 libhunspell-dev libqt5webkit5 libqt5webkit5-dev
+            - os: ubuntu-18.04
+              build_type: qtwebengine
+              qt_version: 5.15.2
+              apt-dependencies: git build-essential cmake libhunspell-dev
+            # TODO: Figure out how to install QtWebKit without installing its dependencies from APT
+            #- os: ubuntu-18.04
+            #  build_type: qtwebkit
+            #  qt_version: 5.15.2
+            # apt-dependencies: git build-essential cmake libhunspell-dev
+            - os: ubuntu-20.04
+              build_type: qtwebkit
+              qt_version: repository
+              apt-dependencies: git build-essential cmake qtbase5-dev libqt5core5a libqt5gui5 libqt5multimedia5 qtmultimedia5-dev libqt5network5 libqt5printsupport5 libqt5qml5 qtdeclarative5-dev libqt5svg5 libqt5svg5-dev libqt5widgets5 libhunspell-dev libqt5webkit5 libqt5webkit5-dev
+            # MacOS fails because libhunspell-dev is missing. See https://github.com/OtterBrowser/otter-browser/issues/1684
+            #- os: macOS-latest
+            #  build_type: qtwebengine
+            #  qt_version: 5.15.2
+            # TODO: Install QtWebKit on MacOS
+            #- os: macOS-latest
+            #  build_type: qtwebkit
+            #  qt_version: 5.15.2
+
+    steps:
+    - name: Get Otter Browser source
+      uses: actions/checkout@v1
+      with:
+        submodules: false
+        fetch-depth: 1
+
+    - name: Install Qt ${{matrix.qt_version}} with QtWebEngine
+      if: startsWith(matrix.os, 'windows') && startsWith(matrix.build_type, 'qtwebengine') || startsWith(matrix.os, 'macos') && startsWith(matrix.build_type, 'qtwebengine') || startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.qt_version, 'repository') && startsWith(matrix.build_type, 'qtwebengine')
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: ${{matrix.qt_version}}
+        modules: qtwebengine
+
+    - name: Install Qt ${{matrix.qt_version}} without QtWebEngine
+      if: startsWith(matrix.os, 'windows') && startsWith(matrix.build_type, 'qtwebkit') || startsWith(matrix.os, 'macos') && startsWith(matrix.build_type, 'qtwebkit') || startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.qt_version, 'repository') && startsWith(matrix.build_type, 'qtwebkit')
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: ${{matrix.qt_version}}
+
+    - name: Install dependencies
+      shell: bash
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+
+        echo "Updating apt repository index"
+        sudo apt update
+
+        echo "Installing apt packages"
+        sudo apt install -y ${{ matrix.apt-dependencies }}
+
+        # Install QtWebKit without installing Qt from the repositories.
+        #if [[ "${{ matrix.build_type }}" = "qtwebkit" && "${{ matrix.qt_version }}" != "repository" ]]; then
+        #    echo "Installing QtWebKit without its dependencies"
+        #    apt-get download libqt5webkit5 libqt5webkit5-dev
+        #    sudo dpkg --force-all -i libqt5webkit5*.deb
+        #fi
+
+    - name: Create Build Environment
+      shell: bash
+      run: cmake -E make_directory "${{runner.workspace}}/build"
+
+    - name: Configure CMake
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake $GITHUB_WORKSPACE
+
+    - name: Build Otter Browser
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --parallel 3
+
+    - name: Output system stats
+      if: ${{ always() }}
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: |
+        echo "Disk usage:"
+        df -h


### PR DESCRIPTION
This PR adds GitHub Action CI builds which automatically test incoming Pull Requests and commits to master on multiple Operating Systems and configurations.

Because of https://github.com/OtterBrowser/otter-browser/issues/1684 and because I haven't figured out how to install libhunspell-dev on Windows and MacOS, both of those don't work yet.

QtWebKit with Qt 5.15.2 also doesn't work because I haven't figured out how to install QtWebKit without installing Qt from APT as well.

Currently this only builds; There is no packaging or even uploading step.