### PR TITLE
Preserve RSS article read status across updates

### DIFF
--- a/src/core/FeedsManager.cpp
+++ b/src/core/FeedsManager.cpp
@@ -269,9 +269,9 @@ void Feed::update()
 											++amount;
 										}
 
+										entry.lastReadTime = existingEntry.lastReadTime;
 										entry.publicationTime = normalizeTime(entry.publicationTime);
 
-										entry.lastReadTime = existingEntry.lastReadTime;
 
 										if (entry.updateTime.isValid())
 										{

--- a/src/core/FeedsManager.cpp
+++ b/src/core/FeedsManager.cpp
@@ -272,7 +272,6 @@ void Feed::update()
 										entry.lastReadTime = existingEntry.lastReadTime;
 										entry.publicationTime = normalizeTime(entry.publicationTime);
 
-
 										if (entry.updateTime.isValid())
 										{
 											entry.updateTime = normalizeTime(entry.updateTime);

--- a/src/core/FeedsManager.cpp
+++ b/src/core/FeedsManager.cpp
@@ -271,6 +271,8 @@ void Feed::update()
 
 										entry.publicationTime = normalizeTime(entry.publicationTime);
 
+										entry.lastReadTime = existingEntry.lastReadTime;
+
 										if (entry.updateTime.isValid())
 										{
 											entry.updateTime = normalizeTime(entry.updateTime);


### PR DESCRIPTION
When a feed updates, the read status of articles are lost; this copies the read time to preserve its read status.

If an article body changed, this will not reset the article's status to unread. This could be done by comparing the update times first.