### PR TITLE
Add menu item to mark all entries in a feed as read

### DIFF
--- a/src/core/FeedsManager.cpp
+++ b/src/core/FeedsManager.cpp
@@ -66,6 +66,16 @@ void Feed::markEntryAsRead(const QString &identifier)
 	}
 }
 
+void Feed::markAllEntriesAsRead()
+{
+	for (int i = 0; i < m_entries.count(); ++i)
+	{
+		m_entries[i].lastReadTime = QDateTime::currentDateTimeUtc();
+	}
+
+	emit feedModified(this);
+}
+
 void Feed::markEntryAsRemoved(const QString &identifier)
 {
 	if (!m_removedEntries.contains(identifier))

--- a/src/core/FeedsManager.cpp
+++ b/src/core/FeedsManager.cpp
@@ -68,9 +68,14 @@ void Feed::markEntryAsRead(const QString &identifier)
 
 void Feed::markAllEntriesAsRead()
 {
+	const QDateTime now = QDateTime::currentDateTimeUtc();
+
 	for (int i = 0; i < m_entries.count(); ++i)
 	{
-		m_entries[i].lastReadTime = QDateTime::currentDateTimeUtc();
+		if (!m_entries[i].lastReadTime.isValid())
+		{
+			m_entries[i].lastReadTime = QDateTime::currentDateTimeUtc();
+		}
 	}
 
 	emit feedModified(this);

--- a/src/core/FeedsManager.cpp
+++ b/src/core/FeedsManager.cpp
@@ -68,13 +68,13 @@ void Feed::markEntryAsRead(const QString &identifier)
 
 void Feed::markAllEntriesAsRead()
 {
-	const QDateTime now = QDateTime::currentDateTimeUtc();
+	const QDateTime currentDateTime(QDateTime::currentDateTimeUtc());
 
 	for (int i = 0; i < m_entries.count(); ++i)
 	{
 		if (!m_entries[i].lastReadTime.isValid())
 		{
-			m_entries[i].lastReadTime = QDateTime::currentDateTimeUtc();
+			m_entries[i].lastReadTime = currentDateTime;
 		}
 	}
 

--- a/src/core/FeedsManager.h
+++ b/src/core/FeedsManager.h
@@ -63,6 +63,7 @@ public:
 	explicit Feed(const QString &title, const QUrl &url, const QIcon &icon, int updateInterval, QObject *parent = nullptr);
 
 	void markEntryAsRead(const QString &identifier);
+	void markAllEntriesAsRead();
 	void markEntryAsRemoved(const QString &identifier);
 	void setTitle(const QString &title);
 	void setDescription(const QString &description);

--- a/src/modules/windows/feeds/FeedsContentsWidget.cpp
+++ b/src/modules/windows/feeds/FeedsContentsWidget.cpp
@@ -314,6 +314,12 @@ void FeedsContentsWidget::removeEntry()
 	}
 }
 
+void FeedsContentsWidget::markEntriesAsRead()
+{
+	m_feed->markAllEntriesAsRead();
+	updateFeedModel();
+}
+
 void FeedsContentsWidget::selectCategory()
 {
 	const QToolButton *toolButton(qobject_cast<QToolButton*>(sender()));
@@ -392,6 +398,7 @@ void FeedsContentsWidget::showFeedsContextMenu(const QPoint &position)
 					if (type == FeedsModel::FeedEntry)
 					{
 						menu.addAction(ThemesManager::createIcon(QLatin1String("view-refresh")), QCoreApplication::translate("actions", "Update"), this, &FeedsContentsWidget::updateFeed);
+						menu.addAction(tr("Mark All as Read"), this, &FeedsContentsWidget::markEntriesAsRead);
 						menu.addSeparator();
 						menu.addAction(ThemesManager::createIcon(QLatin1String("document-open")), QCoreApplication::translate("actions", "Open"), this, &FeedsContentsWidget::openFeed);
 					}

--- a/src/modules/windows/feeds/FeedsContentsWidget.cpp
+++ b/src/modules/windows/feeds/FeedsContentsWidget.cpp
@@ -392,10 +392,8 @@ void FeedsContentsWidget::showFeedsContextMenu(const QPoint &position)
 					if (type == FeedsModel::FeedEntry)
 					{
 						menu.addAction(ThemesManager::createIcon(QLatin1String("view-refresh")), QCoreApplication::translate("actions", "Update"), this, &FeedsContentsWidget::updateFeed);
-
 						menu.addSeparator();
 						menu.addAction(ThemesManager::createIcon(QLatin1String("document-open")), QCoreApplication::translate("actions", "Open"), this, &FeedsContentsWidget::openFeed);
-
 						menu.addSeparator();
 						menu.addAction(tr("Mark All as Read"), this, [&]()
 						{

--- a/src/modules/windows/feeds/FeedsContentsWidget.cpp
+++ b/src/modules/windows/feeds/FeedsContentsWidget.cpp
@@ -314,12 +314,6 @@ void FeedsContentsWidget::removeEntry()
 	}
 }
 
-void FeedsContentsWidget::markEntriesAsRead()
-{
-	m_feed->markAllEntriesAsRead();
-	updateFeedModel();
-}
-
 void FeedsContentsWidget::selectCategory()
 {
 	const QToolButton *toolButton(qobject_cast<QToolButton*>(sender()));
@@ -398,9 +392,20 @@ void FeedsContentsWidget::showFeedsContextMenu(const QPoint &position)
 					if (type == FeedsModel::FeedEntry)
 					{
 						menu.addAction(ThemesManager::createIcon(QLatin1String("view-refresh")), QCoreApplication::translate("actions", "Update"), this, &FeedsContentsWidget::updateFeed);
-						menu.addAction(tr("Mark All as Read"), this, &FeedsContentsWidget::markEntriesAsRead);
+
 						menu.addSeparator();
 						menu.addAction(ThemesManager::createIcon(QLatin1String("document-open")), QCoreApplication::translate("actions", "Open"), this, &FeedsContentsWidget::openFeed);
+
+						menu.addSeparator();
+						menu.addAction(tr("Mark All as Read"), this, [&]()
+						{
+							if (m_feed)
+							{
+								m_feed->markAllEntriesAsRead();
+
+								updateFeedModel();
+							}
+						});
 					}
 
 					menu.addSeparator();

--- a/src/modules/windows/feeds/FeedsContentsWidget.h
+++ b/src/modules/windows/feeds/FeedsContentsWidget.h
@@ -101,6 +101,7 @@ protected slots:
 	void feedProperties();
 	void openEntry();
 	void removeEntry();
+	void markEntriesAsRead();
 	void selectCategory();
 	void handleFeedModified(const QUrl &url);
 	void showEntriesContextMenu(const QPoint &position);

--- a/src/modules/windows/feeds/FeedsContentsWidget.h
+++ b/src/modules/windows/feeds/FeedsContentsWidget.h
@@ -101,7 +101,6 @@ protected slots:
 	void feedProperties();
 	void openEntry();
 	void removeEntry();
-	void markEntriesAsRead();
 	void selectCategory();
 	void handleFeedModified(const QUrl &url);
 	void showEntriesContextMenu(const QPoint &position);


### PR DESCRIPTION
Adds the ability to mark all of a feed's articles as read.

I added this to the left (feed) view for the selected feed. It may make more sense to put it on the entry view.