### PR TITLE
Fix forum URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ Have a look at the [open issues](https://github.com/OtterBrowser/otter-browser/i
 
 We use [Transifex](https://www.transifex.com/otter-browser/otter-browser/) to translate Otter Browser.
 
-To stay informed of Otter development, bug fixes and new features, you can join [the official forum](http://thedndsanctuary.eu/index.php?board=9.0). We also have two IRC channels on Libera.Chat: [#otter-browser](hhttps://web.libera.chat/#otter-browser) (international) and [#otter-browser-pl](https://web.libera.chat/#otter-browser-pl) (polski / Polish).
+To stay informed of Otter development, bug fixes and new features, you can join [the official forum](https://dndsanctuary.eu/index.php?board=9.0). We also have two IRC channels on Libera.Chat: [#otter-browser](hhttps://web.libera.chat/#otter-browser) (international) and [#otter-browser-pl](https://web.libera.chat/#otter-browser-pl) (polski / Polish).
 
 Read *CONTRIBUTING.md* and don’t hesitate!


### PR DESCRIPTION
The current url points to a "this domain is for sale" page 