### PR TITLE
Replace Deprecated/Obsolete 'midRef' and 'fromTime_t'

### DIFF
--- a/src/core/BookmarksManager.cpp
+++ b/src/core/BookmarksManager.cpp
@@ -158,12 +158,12 @@ BookmarksModel::Bookmark* BookmarksManager::getBookmark(const QString &text)
 
 	if (text.startsWith(QLatin1Char('#')))
 	{
-		return m_model->getBookmark(text.midRef(1).toULongLong());
+		return m_model->getBookmark(text.mid(1).toULongLong());
 	}
 
 	if (text.startsWith(QLatin1String("bookmarks:")))
 	{
-		return (text.startsWith(QLatin1String("bookmarks:/")) ? m_model->getBookmarkByPath(text.mid(11)) : getBookmark(text.midRef(10).toULongLong()));
+		return (text.startsWith(QLatin1String("bookmarks:/")) ? m_model->getBookmarkByPath(text.mid(11)) : getBookmark(text.mid(10).toULongLong()));
 	}
 
 	return m_model->getBookmarkByKeyword(text);

--- a/src/core/BookmarksModel.cpp
+++ b/src/core/BookmarksModel.cpp
@@ -1168,7 +1168,7 @@ BookmarksModel::Bookmark* BookmarksModel::getBookmarkByPath(const QString &path,
 
 	if (path.startsWith(QLatin1Char('#')))
 	{
-		return getBookmark(path.midRef(1).toULongLong());
+		return getBookmark(path.mid(1).toULongLong());
 	}
 
 	Bookmark *bookmark(m_rootItem);

--- a/src/core/InputInterpreter.cpp
+++ b/src/core/InputInterpreter.cpp
@@ -71,7 +71,7 @@ InputInterpreter::InterpreterResult InputInterpreter::interpret(const QString &t
 
 	if (text.startsWith(QLatin1String("bookmarks:")))
 	{
-		BookmarksModel::Bookmark *bookmark(text.startsWith(QLatin1String("bookmarks:/")) ? BookmarksManager::getModel()->getBookmarkByPath(text.mid(11)) : BookmarksManager::getBookmark(text.midRef(10).toULongLong()));
+		BookmarksModel::Bookmark *bookmark(text.startsWith(QLatin1String("bookmarks:/")) ? BookmarksManager::getModel()->getBookmarkByPath(text.mid(11)) : BookmarksManager::getBookmark(text.mid(10).toULongLong()));
 
 		if (bookmark)
 		{

--- a/src/core/NetworkAutomaticProxy.cpp
+++ b/src/core/NetworkAutomaticProxy.cpp
@@ -78,7 +78,7 @@ int PacUtils::dnsDomainLevels(const QString &host) const
 {
 	if (host.startsWith(QLatin1String("www."), Qt::CaseInsensitive))
 	{
-		return host.midRef(4).count(QLatin1Char('.'));
+		return host.mid(4).count(QLatin1Char('.'));
 	}
 
 	return host.count(QLatin1Char('.'));

--- a/src/modules/importers/opera/OperaBookmarksImportDataExchanger.cpp
+++ b/src/modules/importers/opera/OperaBookmarksImportDataExchanger.cpp
@@ -285,11 +285,11 @@ void OperaBookmarksImportJob::start()
 			}
 			else if (line.startsWith(QLatin1String("\tCREATED=")))
 			{
-				bookmark->setData(QDateTime::fromTime_t(line.section(QLatin1Char('='), 1, -1).toUInt()), BookmarksModel::TimeAddedRole);
+				bookmark->setData(QDateTime::fromSecsSinceEpoch(line.section(QLatin1Char('='), 1, -1).toUInt()), BookmarksModel::TimeAddedRole);
 			}
 			else if (line.startsWith(QLatin1String("\tVISITED=")))
 			{
-				bookmark->setData(QDateTime::fromTime_t(line.section(QLatin1Char('='), 1, -1).toUInt()), BookmarksModel::TimeVisitedRole);
+				bookmark->setData(QDateTime::fromSecsSinceEpoch(line.section(QLatin1Char('='), 1, -1).toUInt()), BookmarksModel::TimeVisitedRole);
 			}
 		}
 	}

--- a/src/modules/importers/opera/OperaNotesImportDataExchanger.cpp
+++ b/src/modules/importers/opera/OperaNotesImportDataExchanger.cpp
@@ -243,7 +243,7 @@ bool OperaNotesImportDataExchanger::importData(const QString &path)
 			}
 			else if (line.startsWith(QLatin1String("\tCREATED=")))
 			{
-				note->setData(QDateTime::fromTime_t(line.section(QLatin1Char('='), 1, -1).toUInt()), BookmarksModel::TimeAddedRole);
+				note->setData(QDateTime::fromSecsSinceEpoch(line.section(QLatin1Char('='), 1, -1).toUInt()), BookmarksModel::TimeAddedRole);
 			}
 		}
 	}

--- a/src/ui/ToolBarDialog.cpp
+++ b/src/ui/ToolBarDialog.cpp
@@ -445,7 +445,7 @@ void ToolBarDialog::editEntry()
 		}
 		else if (identifier.startsWith(QLatin1String("bookmarks:")))
 		{
-			const BookmarksModel::Bookmark *bookmark(identifier.startsWith(QLatin1String("bookmarks:/")) ? BookmarksManager::getModel()->getBookmarkByPath(identifier.mid(11)) : BookmarksManager::getBookmark(identifier.midRef(10).toULongLong()));
+			const BookmarksModel::Bookmark *bookmark(identifier.startsWith(QLatin1String("bookmarks:/")) ? BookmarksManager::getModel()->getBookmarkByPath(identifier.mid(11)) : BookmarksManager::getBookmark(identifier.mid(10).toULongLong()));
 
 			if (bookmark)
 			{
@@ -791,7 +791,7 @@ QMap<int, QVariant> ToolBarDialog::createEntryData(const QString &identifier, co
 	}
 	else if (identifier.startsWith(QLatin1String("bookmarks:")))
 	{
-		const BookmarksModel::Bookmark *bookmark(identifier.startsWith(QLatin1String("bookmarks:/")) ? BookmarksManager::getModel()->getBookmarkByPath(identifier.mid(11)) : BookmarksManager::getBookmark(identifier.midRef(10).toULongLong()));
+		const BookmarksModel::Bookmark *bookmark(identifier.startsWith(QLatin1String("bookmarks:/")) ? BookmarksManager::getModel()->getBookmarkByPath(identifier.mid(11)) : BookmarksManager::getBookmark(identifier.mid(10).toULongLong()));
 
 		if (bookmark)
 		{

--- a/src/ui/WidgetFactory.cpp
+++ b/src/ui/WidgetFactory.cpp
@@ -164,7 +164,7 @@ QWidget* createToolBarItem(const ToolBarsManager::ToolBarDefinition::Entry &defi
 
 	if (definition.action.startsWith(QLatin1String("bookmarks:")))
 	{
-		BookmarksModel::Bookmark *bookmark(definition.action.startsWith(QLatin1String("bookmarks:/")) ? BookmarksManager::getModel()->getBookmarkByPath(definition.action.mid(11)) : BookmarksManager::getBookmark(definition.action.midRef(10).toULongLong()));
+		BookmarksModel::Bookmark *bookmark(definition.action.startsWith(QLatin1String("bookmarks:/")) ? BookmarksManager::getModel()->getBookmarkByPath(definition.action.mid(11)) : BookmarksManager::getBookmark(definition.action.mid(10).toULongLong()));
 
 		if (bookmark)
 		{


### PR DESCRIPTION
Changes picked from the Qt 6 port [1] which are compatible with Qt 5.

1. https://github.com/OtterBrowser/otter-browser/pull/1770
