### PR TITLE
Resolve crash on tab switch (#1769)

### DIFF
--- a/src/ui/TabSwitcherWidget.cpp
+++ b/src/ui/TabSwitcherWidget.cpp
@@ -274,8 +274,11 @@ void TabSwitcherWidget::handleWindowRemoved(quint64 identifier)
 	}
 }
 
-QStandardItem* TabSwitcherWidget::createRow(Window *window, const QVariant &index) const
+QStandardItem* TabSwitcherWidget::createRow(QPointer<Window> window, const QVariant &index) const
 {
+	if (!window) return nullptr;
+
+	const auto windowIdentifier = window->getIdentifier();
 	QColor color(palette().color(QPalette::Text));
 
 	if (window->getLoadingState() == WebWidget::DeferredLoadingState)
@@ -285,13 +288,13 @@ QStandardItem* TabSwitcherWidget::createRow(Window *window, const QVariant &inde
 
 	QStandardItem *item(new QStandardItem(window->getIcon(), window->getTitle()));
 	item->setData(color, Qt::ForegroundRole);
-	item->setData(window->getIdentifier(), IdentifierRole);
+	item->setData(windowIdentifier, IdentifierRole);
 	item->setData(index, OrderRole);
 	item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 
 	connect(window, &Window::titleChanged, this, [&](const QString &title)
 	{
-		const int row(findRow(window->getIdentifier()));
+		const int row(findRow(windowIdentifier));
 
 		if (row >= 0)
 		{
@@ -300,7 +303,7 @@ QStandardItem* TabSwitcherWidget::createRow(Window *window, const QVariant &inde
 	});
 	connect(window, &Window::iconChanged, this, [&](const QIcon &icon)
 	{
-		const int row(findRow(window->getIdentifier()));
+		const int row(findRow(windowIdentifier));
 
 		if (row >= 0)
 		{
@@ -309,7 +312,7 @@ QStandardItem* TabSwitcherWidget::createRow(Window *window, const QVariant &inde
 	});
 	connect(window, &Window::loadingStateChanged, this, [&](WebWidget::LoadingState state)
 	{
-		const int row(findRow(window->getIdentifier()));
+		const int row(findRow(windowIdentifier));
 
 		if (row >= 0)
 		{

--- a/src/ui/TabSwitcherWidget.h
+++ b/src/ui/TabSwitcherWidget.h
@@ -62,7 +62,7 @@ protected:
 	void hideEvent(QHideEvent *event) override;
 	void keyPressEvent(QKeyEvent *event) override;
 	void keyReleaseEvent(QKeyEvent *event) override;
-	QStandardItem* createRow(Window *window, const QVariant &index) const;
+	QStandardItem* createRow(QPointer<Window> window, const QVariant &index) const;
 	int findRow(quint64 identifier) const;
 
 protected slots:


### PR DESCRIPTION
Fixed crash by avoiding dangling window pointer in TabSwitcherWidget callbacks.

<details>
<summary>Stack trace</summary>

```cpp
otter-browser.exe!Otter::Window::getIdentifier() Line 714 (c:\Projects\otter-browser\src\ui\Window.cpp:714)
otter-browser.exe!Otter::TabSwitcherWidget::createRow::__l2::<lambda>(const QString & title) Line 294 (c:\Projects\otter-browser\src\ui\TabSwitcherWidget.cpp:294)
otter-browser.exe!QtPrivate::FunctorCall<QtPrivate::IndexesList<0>,QtPrivate::List<QString const &>,void,void <lambda>(const QString &)>::call(Otter::TabSwitcherWidget::createRow::__l2::void <lambda>(const QString &) & f, void * * arg) Line 146 (c:\Qt-5.15.0\5.15.0\msvc2019_64\include\QtCore\qobjectdefs_impl.h:146)
otter-browser.exe!QtPrivate::Functor<void <lambda>(const QString &),1>::call<QtPrivate::List<QString const &>,void>(Otter::TabSwitcherWidget::createRow::__l2::void <lambda>(const QString &) & f, void * __formal, void * * arg) Line 256 (c:\Qt-5.15.0\5.15.0\msvc2019_64\include\QtCore\qobjectdefs_impl.h:256)
otter-browser.exe!QtPrivate::QFunctorSlotObject<void <lambda>(const QString &),1,QtPrivate::List<QString const &>,void>::impl(int which, QtPrivate::QSlotObjectBase * this_, QObject * r, void * * a, bool * ret) Line 443 (c:\Qt-5.15.0\5.15.0\msvc2019_64\include\QtCore\qobjectdefs_impl.h:443)
Qt5Cored.dll!QtPrivate::QSlotObjectBase::call(QObject * r, void * * a) Line 398 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qobjectdefs_impl.h:398)
Qt5Cored.dll!doActivate<0>(QObject * sender, int signal_index, void * * argv) Line 3886 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qobject.cpp:3886)
Qt5Cored.dll!QMetaObject::activate(QObject * sender, const QMetaObject * m, int local_signal_index, void * * argv) Line 3947 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qobject.cpp:3947)
otter-browser.exe!Otter::Window::titleChanged(const QString & _t1) Line 545 (c:\Projects\otter-browser\build\otter-browser_autogen\YPKJ5OE7LN\moc_Window.cpp:545)
otter-browser.exe!QtPrivate::FunctorCall<QtPrivate::IndexesList<0>,QtPrivate::List<QString const &>,void,void (__cdecl Otter::Window::*)(QString const &)>::call(void(Otter::Window::*)(const QString &) f, Otter::Window * o, void * * arg) Line 152 (c:\Qt-5.15.0\5.15.0\msvc2019_64\include\QtCore\qobjectdefs_impl.h:152)
otter-browser.exe!QtPrivate::FunctionPointer<void (__cdecl Otter::Window::*)(QString const &)>::call<QtPrivate::List<QString const &>,void>(void(Otter::Window::*)(const QString &) f, Otter::Window * o, void * * arg) Line 185 (c:\Qt-5.15.0\5.15.0\msvc2019_64\include\QtCore\qobjectdefs_impl.h:185)
otter-browser.exe!QtPrivate::QSlotObject<void (__cdecl Otter::Window::*)(QString const &),QtPrivate::List<QString const &>,void>::impl(int which, QtPrivate::QSlotObjectBase * this_, QObject * r, void * * a, bool * ret) Line 418 (c:\Qt-5.15.0\5.15.0\msvc2019_64\include\QtCore\qobjectdefs_impl.h:418)
Qt5Cored.dll!QtPrivate::QSlotObjectBase::call(QObject * r, void * * a) Line 398 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qobjectdefs_impl.h:398)
Qt5Cored.dll!doActivate<0>(QObject * sender, int signal_index, void * * argv) Line 3886 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qobject.cpp:3886)
Qt5Cored.dll!QMetaObject::activate(QObject * sender, const QMetaObject * m, int local_signal_index, void * * argv) Line 3947 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qobject.cpp:3947)
otter-browser.exe!Otter::ContentsWidget::titleChanged(const QString & _t1) Line 550 (c:\Projects\otter-browser\build\otter-browser_autogen\YPKJ5OE7LN\moc_ContentsWidget.cpp:550)
otter-browser.exe!QtPrivate::FunctorCall<QtPrivate::IndexesList<0>,QtPrivate::List<QString const &>,void,void (__cdecl Otter::ContentsWidget::*)(QString const &)>::call(void(Otter::ContentsWidget::*)(const QString &) f, Otter::ContentsWidget * o, void * * arg) Line 152 (c:\Qt-5.15.0\5.15.0\msvc2019_64\include\QtCore\qobjectdefs_impl.h:152)
otter-browser.exe!QtPrivate::FunctionPointer<void (__cdecl Otter::ContentsWidget::*)(QString const &)>::call<QtPrivate::List<QString const &>,void>(void(Otter::ContentsWidget::*)(const QString &) f, Otter::ContentsWidget * o, void * * arg) Line 185 (c:\Qt-5.15.0\5.15.0\msvc2019_64\include\QtCore\qobjectdefs_impl.h:185)
otter-browser.exe!QtPrivate::QSlotObject<void (__cdecl Otter::ContentsWidget::*)(QString const &),QtPrivate::List<QString const &>,void>::impl(int which, QtPrivate::QSlotObjectBase * this_, QObject * r, void * * a, bool * ret) Line 418 (c:\Qt-5.15.0\5.15.0\msvc2019_64\include\QtCore\qobjectdefs_impl.h:418)
Qt5Cored.dll!QtPrivate::QSlotObjectBase::call(QObject * r, void * * a) Line 398 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qobjectdefs_impl.h:398)
Qt5Cored.dll!doActivate<0>(QObject * sender, int signal_index, void * * argv) Line 3886 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qobject.cpp:3886)
Qt5Cored.dll!QMetaObject::activate(QObject * sender, const QMetaObject * m, int local_signal_index, void * * argv) Line 3947 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qobject.cpp:3947)
otter-browser.exe!Otter::WebWidget::titleChanged(const QString & _t1) Line 740 (c:\Projects\otter-browser\build\otter-browser_autogen\YPKJ5OE7LN\moc_WebWidget.cpp:740)
otter-browser.exe!Otter::QtWebEngineWebWidget::notifyTitleChanged() Line 1101 (c:\Projects\otter-browser\src\modules\backends\web\qtwebengine\QtWebEngineWebWidget.cpp:1101)
otter-browser.exe!Otter::QtWebEngineWebWidget::setUrl(const QUrl & url, bool isTypedIn) Line 1384 (c:\Projects\otter-browser\src\modules\backends\web\qtwebengine\QtWebEngineWebWidget.cpp:1384)
otter-browser.exe!Otter::WebWidget::setRequestedUrl(const QUrl & url, bool isTypedIn, bool updateOnly) Line 783 (c:\Projects\otter-browser\src\ui\WebWidget.cpp:783)
otter-browser.exe!Otter::WebContentsWidget::setUrl(const QUrl & url, bool isTypedIn) Line 1300 (c:\Projects\otter-browser\src\modules\windows\web\WebContentsWidget.cpp:1300)
otter-browser.exe!Otter::Window::setUrl(const QUrl & url, bool isTypedIn) Line 369 (c:\Projects\otter-browser\src\ui\Window.cpp:369)
otter-browser.exe!Otter::MainWindow::triggerAction(int identifier, const QMap<QString,QVariant> & parameters, Otter::ActionsManager::TriggerType trigger) Line 751 (c:\Projects\otter-browser\src\ui\MainWindow.cpp:751)
otter-browser.exe!Otter::ActionExecutor::Object::triggerAction(int identifier, const QMap<QString,QVariant> & parameters, Otter::ActionsManager::TriggerType trigger) Line 98 (c:\Projects\otter-browser\src\core\ActionExecutor.cpp:98)
otter-browser.exe!Otter::AddressWidget::handleUserInput(const QString & text, QFlags<enum Otter::SessionsManager::OpenHint> hints) Line 971 (c:\Projects\otter-browser\src\modules\widgets\address\AddressWidget.cpp:971)
otter-browser.exe!Otter::AddressWidget::keyPressEvent(QKeyEvent * event) Line 444 (c:\Projects\otter-browser\src\modules\widgets\address\AddressWidget.cpp:444)
Qt5Widgetsd.dll!QWidget::event(QEvent * event) Line 8714 (c:\Users\qt\work\qt\qtbase\src\widgets\kernel\qwidget.cpp:8714)
Qt5Widgetsd.dll!QLineEdit::event(QEvent * e) Line 1532 (c:\Users\qt\work\qt\qtbase\src\widgets\widgets\qlineedit.cpp:1532)
otter-browser.exe!Otter::AddressWidget::event(QEvent * event) Line 1544 (c:\Projects\otter-browser\src\modules\widgets\address\AddressWidget.cpp:1544)
Qt5Widgetsd.dll!QApplicationPrivate::notify_helper(QObject * receiver, QEvent * e) Line 3671 (c:\Users\qt\work\qt\qtbase\src\widgets\kernel\qapplication.cpp:3671)
Qt5Widgetsd.dll!QApplication::notify(QObject * receiver, QEvent * e) Line 3033 (c:\Users\qt\work\qt\qtbase\src\widgets\kernel\qapplication.cpp:3033)
Qt5Cored.dll!QCoreApplication::notifyInternal2(QObject * receiver, QEvent * event) Line 1061 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qcoreapplication.cpp:1061)
Qt5Cored.dll!QCoreApplication::forwardEvent(QObject * receiver, QEvent * event, QEvent * originatingEvent) Line 1077 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qcoreapplication.cpp:1077)
Qt5Widgetsd.dll!QWidgetWindow::handleKeyEvent(QKeyEvent * event) Line 716 (c:\Users\qt\work\qt\qtbase\src\widgets\kernel\qwidgetwindow.cpp:716)
Qt5Widgetsd.dll!QWidgetWindow::event(QEvent * event) Line 289 (c:\Users\qt\work\qt\qtbase\src\widgets\kernel\qwidgetwindow.cpp:289)
Qt5Widgetsd.dll!QApplicationPrivate::notify_helper(QObject * receiver, QEvent * e) Line 3671 (c:\Users\qt\work\qt\qtbase\src\widgets\kernel\qapplication.cpp:3671)
Qt5Widgetsd.dll!QApplication::notify(QObject * receiver, QEvent * e) Line 3011 (c:\Users\qt\work\qt\qtbase\src\widgets\kernel\qapplication.cpp:3011)
Qt5Cored.dll!QCoreApplication::notifyInternal2(QObject * receiver, QEvent * event) Line 1061 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qcoreapplication.cpp:1061)
Qt5Cored.dll!QCoreApplication::sendSpontaneousEvent(QObject * receiver, QEvent * event) Line 1469 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qcoreapplication.cpp:1469)
Qt5Guid.dll!QGuiApplicationPrivate::processKeyEvent(QWindowSystemInterfacePrivate::KeyEvent * e) Line 2363 (c:\Users\qt\work\qt\qtbase\src\gui\kernel\qguiapplication.cpp:2363)
Qt5Guid.dll!QGuiApplicationPrivate::processWindowSystemEvent(QWindowSystemInterfacePrivate::WindowSystemEvent * e) Line 1953 (c:\Users\qt\work\qt\qtbase\src\gui\kernel\qguiapplication.cpp:1953)
Qt5Guid.dll!QWindowSystemInterface::sendWindowSystemEvents(QFlags<enum QEventLoop::ProcessEventsFlag> flags) Line 1181 (c:\Users\qt\work\qt\qtbase\src\gui\kernel\qwindowsysteminterface.cpp:1181)
qwindowsd.dll!QWindowsGuiEventDispatcher::sendPostedEvents() Line 82 (c:\Users\qt\work\qt\qtbase\src\platformsupport\eventdispatchers\qwindowsguieventdispatcher.cpp:82)
Qt5Cored.dll!QEventDispatcherWin32::processEvents(QFlags<enum QEventLoop::ProcessEventsFlag> flags) Line 527 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qeventdispatcher_win.cpp:527)
qwindowsd.dll!QWindowsGuiEventDispatcher::processEvents(QFlags<enum QEventLoop::ProcessEventsFlag> flags) Line 73 (c:\Users\qt\work\qt\qtbase\src\platformsupport\eventdispatchers\qwindowsguieventdispatcher.cpp:73)
Qt5Cored.dll!QEventLoop::processEvents(QFlags<enum QEventLoop::ProcessEventsFlag> flags) Line 140 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qeventloop.cpp:140)
Qt5Cored.dll!QEventLoop::exec(QFlags<enum QEventLoop::ProcessEventsFlag> flags) Line 232 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qeventloop.cpp:232)
Qt5Cored.dll!QCoreApplication::exec() Line 1369 (c:\Users\qt\work\qt\qtbase\src\corelib\kernel\qcoreapplication.cpp:1369)
Qt5Guid.dll!QGuiApplication::exec() Line 1868 (c:\Users\qt\work\qt\qtbase\src\gui\kernel\qguiapplication.cpp:1868)
Qt5Widgetsd.dll!QApplication::exec() Line 2812 (c:\Users\qt\work\qt\qtbase\src\widgets\kernel\qapplication.cpp:2812)
otter-browser.exe!main(int argc, char * * argv) Line 252 (c:\Projects\otter-browser\src\main.cpp:252)
otter-browser.exe!invoke_main() Line 79 (d:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:79)
otter-browser.exe!__scrt_common_main_seh() Line 288 (d:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
otter-browser.exe!__scrt_common_main() Line 331 (d:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:331)
otter-browser.exe!mainCRTStartup(void * __formal) Line 17 (d:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:17)
kernel32.dll!00007ff85dcfe8d7() (Unknown Source:0)
ntdll.dll!00007ff85ea5c34c() (Unknown Source:0)
```
</details>