### PR TITLE
MiddleClick uses correct clipboard

### DIFF
--- a/src/modules/widgets/address/AddressWidget.cpp
+++ b/src/modules/widgets/address/AddressWidget.cpp
@@ -1,5 +1,6 @@
 /**************************************************************************
 * Otter Browser: Web browser controlled by the user, not vice-versa.
+* Copyright (C) 2026 Jonas Bechtel
 * Copyright (C) 2013 - 2024 Michal Dutkiewicz aka Emdek <michal@emdek.pl>
 * Copyright (C) 2014 - 2017 Jan Bajer aka bajasoft <jbajer@gmail.com>
 * Copyright (C) 2014 Piotr Wójcik <chocimier@tlen.pl>

--- a/src/modules/widgets/address/AddressWidget.cpp
+++ b/src/modules/widgets/address/AddressWidget.cpp
@@ -713,7 +713,11 @@ void AddressWidget::mouseReleaseEvent(QMouseEvent *event)
 	}
 	else if (event->button() == Qt::MiddleButton && text().isEmpty() && !QGuiApplication::clipboard()->text().isEmpty() && SettingsManager::getOption(SettingsManager::AddressField_PasteAndGoOnMiddleClickOption).toBool())
 	{
-		handleUserInput(QGuiApplication::clipboard()->text().trimmed(), SessionsManager::CurrentTabOpen);
+		auto clipboard = QGuiApplication::clipboard();
+		auto mode = QClipboard::Clipboard;
+		if (clipboard->supportsSelection())
+			mode = QClipboard::Selection;
+		handleUserInput(clipboard->text(mode).trimmed(), SessionsManager::CurrentTabOpen);
 
 		event->accept();
 	}


### PR DESCRIPTION
This is relevant for X11 systems (usually GNU/Linux) which have two clipboards.

Without this commit the Selection content is copied into the urlbar whereas the Clipboard content is used to invoke the website. This has made me giving private information to Duckduckgo because it was some sentence from some letter which accidentally became a search term while I was about to invoke an HTTP URL.