### PR TITLE
.gitignore: More build directories (and auxilary files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 *~
 build
+build1
+build2
+build3
+build_qt*
 GeneratedFiles
 release
 Win32

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ debug
 *.user
 .kde4
 *.kde4
+.*.swp
+.*.swo
+.gdb_history


### PR DESCRIPTION
When building the browser for both Qt5 and Qt6 you need several build dirs. Hereby I suggest to facilitate more such dirs:

- build1
- build2
- build3
- build_qt*

Maybe it would make more sense to wildcard to allow for even more, e.g.:

- build*

(in latter case this pull doesn't make sense of course)

EDIT: Now also some editor swap files and gdb history in this pull request.