### PR TITLE
Add Array.at() as pseudo userscript (Support Mastodon 4.6)

### DIFF
--- a/src/modules/backends/web/qtwebengine/QtWebEnginePage.cpp
+++ b/src/modules/backends/web/qtwebengine/QtWebEnginePage.cpp
@@ -594,17 +594,20 @@ bool QtWebEnginePage::acceptNavigationRequest(const QUrl &url, NavigationType ty
 
 	QWebEngineScript script2;
 	script2.setSourceCode(
+		"if(!Array.prototype.hasOwnProperty(\"at\")) {\n"
 		"	Object.defineProperty(Array.prototype, \"at\", \n"
 		"		{\n"
 		"			value:      function () {return 0},\n" // "this" not avail.
 		"			enumerable: false,\n"  // -> do not appear in for(i in arr)
 		"			writable:   true,\n" // -> allow overwrite in next statement
-		"		})\n"
+		"		}\n"
+		"	)\n"
 		"	Array.prototype.at = function (index) {\n"  // overwrite
 		"		if (index < 0)\n"
 		"			index += this.length\n"
 		"		return this[index]\n" // "this" available here
 		"	}\n"
+		"}\n"
 	);
 	script2.setRunsOnSubFrames(true);
 	script2.setInjectionPoint(QWebEngineScript::DocumentCreation);

--- a/src/modules/backends/web/qtwebengine/QtWebEnginePage.cpp
+++ b/src/modules/backends/web/qtwebengine/QtWebEnginePage.cpp
@@ -591,6 +591,13 @@ bool QtWebEnginePage::acceptNavigationRequest(const QUrl &url, NavigationType ty
 		scripts().insert(script);
 	}
 
+	QWebEngineScript script2;
+	script2.setSourceCode("Array.prototype.at = function (index) {if (index < 0) index += this.length; return this[index];};");
+	script2.setRunsOnSubFrames(true);
+	script2.setInjectionPoint(QWebEngineScript::DocumentCreation);
+	script2.setWorldId(QWebEngineScript::MainWorld);
+	scripts().insert(script2);
+
 	emit aboutToNavigate(url, type);
 
 	return true;

--- a/src/modules/backends/web/qtwebengine/QtWebEnginePage.cpp
+++ b/src/modules/backends/web/qtwebengine/QtWebEnginePage.cpp
@@ -1,5 +1,6 @@
 /**************************************************************************
 * Otter Browser: Web browser controlled by the user, not vice-versa.
+* Copyright (C) 2026 Jonas Bechtel (temporary for polyfill)
 * Copyright (C) 2015 - 2025 Michal Dutkiewicz aka Emdek <michal@emdek.pl>
 * Copyright (C) 2016 - 2017 Jan Bajer aka bajasoft <jbajer@gmail.com>
 *
@@ -593,10 +594,16 @@ bool QtWebEnginePage::acceptNavigationRequest(const QUrl &url, NavigationType ty
 
 	QWebEngineScript script2;
 	script2.setSourceCode(
-		"	Array.prototype.at = function (index) {\n"
+		"	Object.defineProperty(Array.prototype, \"at\", \n"
+		"		{\n"
+		"			value:      function () {return 0},\n" // "this" not avail.
+		"			enumerable: false,\n"  // -> do not appear in for(i in arr)
+		"			writable:   true,\n" // -> allow overwrite in next statement
+		"		})\n"
+		"	Array.prototype.at = function (index) {\n"  // overwrite
 		"		if (index < 0)\n"
 		"			index += this.length\n"
-		"		return this[index]\n"
+		"		return this[index]\n" // "this" available here
 		"	}\n"
 	);
 	script2.setRunsOnSubFrames(true);

--- a/src/modules/backends/web/qtwebengine/QtWebEnginePage.cpp
+++ b/src/modules/backends/web/qtwebengine/QtWebEnginePage.cpp
@@ -592,7 +592,13 @@ bool QtWebEnginePage::acceptNavigationRequest(const QUrl &url, NavigationType ty
 	}
 
 	QWebEngineScript script2;
-	script2.setSourceCode("Array.prototype.at = function (index) {if (index < 0) index += this.length; return this[index];};");
+	script2.setSourceCode(
+		"	Array.prototype.at = function (index) {\n"
+		"		if (index < 0)\n"
+		"			index += this.length\n"
+		"		return this[index]\n"
+		"	}\n"
+	);
 	script2.setRunsOnSubFrames(true);
 	script2.setInjectionPoint(QWebEngineScript::DocumentCreation);
 	script2.setWorldId(QWebEngineScript::MainWorld);


### PR DESCRIPTION
The emoji handler in Mastodon 4.6 introduced the use of Array.at() function and breaks the whole site if this function is unavailable.

So to display the site, a „polyfill“ is needed, I learned from https://github.com/mastodon/mastodon/pull/39583 . So here I considered introducing this at browser level.